### PR TITLE
Fix workflow sandbox error with eth-account

### DIFF
--- a/tools/wallet.py
+++ b/tools/wallet.py
@@ -39,7 +39,7 @@ async def send_tx(signed_hex: str, rpc_url: str) -> str:
     return tx_hash.hex()
 
 
-@workflow.defn
+@workflow.defn(sandboxed=False)
 class SignAndSendTx:
     """Workflow to sign a transaction and send it to an EVM chain."""
 


### PR DESCRIPTION
## Summary
- disable sandboxing for the wallet workflow

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'temporalio')*

------
https://chatgpt.com/codex/tasks/task_e_6848cccd57c48330b829f525d3f4d810