### PR TITLE
Fix eth_account import for workflow sandbox

### DIFF
--- a/tools/wallet.py
+++ b/tools/wallet.py
@@ -6,7 +6,6 @@ import os
 from datetime import timedelta
 from typing import Dict
 
-from eth_account import Account
 from pydantic import BaseModel
 from temporalio import activity, workflow
 from temporalio.common import RetryPolicy
@@ -21,6 +20,8 @@ class SignedTx(BaseModel):
 @activity.defn
 async def build_signed_tx(raw_tx: dict, private_key: str) -> dict:
     """Sign ``raw_tx`` with ``private_key`` and return hex data."""
+    from eth_account import Account
+
     signed = Account.sign_transaction(raw_tx, private_key)
     return {
         "rawTransaction": signed.rawTransaction.hex(),


### PR DESCRIPTION
## Summary
- avoid importing eth_account at module load time

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'temporalio')*

------
https://chatgpt.com/codex/tasks/task_e_6848d030e3c483308ed711ec51a26e5c