### PR TITLE
Fix MCP server default port

### DIFF
--- a/mcp_server/app.py
+++ b/mcp_server/app.py
@@ -151,4 +151,6 @@ async def workflow_status(request: Request) -> Response:
 
 
 if __name__ == "__main__":
-    app.run()
+    host = os.environ.get("MCP_HOST", "0.0.0.0")
+    port = int(os.environ.get("MCP_PORT", "8080"))
+    app.run(host=host, port=port)


### PR DESCRIPTION
## Summary
- fix mcp server default host/port to match README and agents

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'temporalio')*

------
https://chatgpt.com/codex/tasks/task_e_6849c37d57c4833090fa7df4c21d09c0