### PR TITLE
Fix momentum agent path typo and delay start

### DIFF
--- a/run_stack.sh
+++ b/run_stack.sh
@@ -51,12 +51,12 @@ tmux send-keys    -t $MCP_PANE 'source .venv/bin/activate && python mcp_server/a
 # 4. Pane 3 – feature engineering agent (split Pane 1 horizontally →)
 tmux select-pane  -t $WORKER_PANE
 FE_PANE=$(tmux split-window -h -P -F "#{pane_id}")
-tmux send-keys    -t $FE_PANE 'source .venv/bin/activate && python agents/feature_engineering_agent.py' C-m
+tmux send-keys    -t $FE_PANE 'sleep 2 && source .venv/bin/activate && python agents/feature_engineering_agent.py' C-m
 
 # 5. Pane 4 – momentum strategy agent (split Pane 3 vertically ↓)
 tmux select-pane  -t $FE_PANE
 MOM_PANE=$(tmux split-window -v -P -F "#{pane_id}")
-tmux send-keys    -t $MOM_PANE 'source .venv/bin/activate && python ageints/strategies/momentum_agent.py' C-m
+tmux send-keys    -t $MOM_PANE 'sleep 2 && source .venv/bin/activate && python agents/strategies/momentum_agent.py' C-m
 
 # 6. Attach user to session
 tmux select-pane -t $SESSION:0.0    # focus top-left pane


### PR DESCRIPTION
## Summary
- fix broken path in run_stack.sh
- add slight delay before launching feature engineering and momentum agents so the MCP server is ready

## Testing
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'temporalio')*

------
https://chatgpt.com/codex/tasks/task_e_6849e58a25cc8330a300e3006faa25b5