### PR TITLE
Fix activity invocation parameters

### DIFF
--- a/tools/market_data.py
+++ b/tools/market_data.py
@@ -65,8 +65,7 @@ class SubscribeCEXStream:
             for symbol in symbols:
                 ticker = await workflow.execute_activity(
                     fetch_ticker,
-                    exchange,
-                    symbol,
+                    args=[exchange, symbol],
                     schedule_to_close_timeout=timedelta(seconds=10),
                 )
                 await workflow.execute_activity(

--- a/tools/wallet.py
+++ b/tools/wallet.py
@@ -54,15 +54,13 @@ class SignAndSendTx:
 
         signed = await workflow.execute_activity(
             build_signed_tx,
-            raw_tx,
-            privkey,
+            args=[raw_tx, privkey],
             schedule_to_close_timeout=timedelta(seconds=10),
             retry_policy=RetryPolicy(maximum_attempts=3),
         )
         tx_hash = await workflow.execute_activity(
             send_tx,
-            signed["rawTransaction"],
-            rpc_url,
+            args=[signed["rawTransaction"], rpc_url],
             schedule_to_close_timeout=timedelta(seconds=120),
             retry_policy=RetryPolicy(maximum_attempts=3),
         )


### PR DESCRIPTION
## Summary
- fix misuse of `workflow.execute_activity` when providing multiple parameters
- adjust wallet workflow accordingly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'temporalio')*

------
https://chatgpt.com/codex/tasks/task_e_6849f09387748330a348a3ea5221e1e2