### PR TITLE
Switch default exchange to Coinbase

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,11 @@ $ pip install -r requirements.txt
 $ npm install
 $ npm run dev
 
+
 Point your agent workers at localhost:8080 (default MCP port) and confirm health at http://localhost:8080/healthz.
+
+If Binance is blocked in your region, pass `"exchange": "coinbaseexchange"` when starting workflows such as `SubscribeCEXStream`.  Use trading pairs like `BTC/USD`.
+For private Coinbase endpoints, set `COINBASEEXCHANGE_API_KEY` and `COINBASEEXCHANGE_SECRET` in your environment.
 
 Development Workflow
 

--- a/agents/feature_engineering_agent.py
+++ b/agents/feature_engineering_agent.py
@@ -20,7 +20,7 @@ logging.basicConfig(level=logging.INFO)
 
 MCP_HOST = os.environ.get("MCP_HOST", "localhost")
 MCP_PORT = os.environ.get("MCP_PORT", "8080")
-SYMBOLS = [s.strip() for s in os.environ.get("SYMBOLS", "BTC/USDT").split(",")]
+SYMBOLS = [s.strip() for s in os.environ.get("SYMBOLS", "BTC/USD").split(",")]
 LOG_EVERY = int(os.environ.get("LOG_EVERY", "10"))
 
 STOP_EVENT = asyncio.Event()

--- a/agents/strategies/momentum_agent.py
+++ b/agents/strategies/momentum_agent.py
@@ -48,7 +48,7 @@ logger = logging.getLogger(__name__)
 
 MCP_HOST = os.environ.get("MCP_HOST", "localhost")
 MCP_PORT = os.environ.get("MCP_PORT", "8080")
-SYMBOL = os.environ.get("SYMBOL", "BTC/USDT")
+SYMBOL = os.environ.get("SYMBOL", "BTC/USD")
 COOLDOWN_SEC = int(os.environ.get("COOLDOWN_SEC", "30"))
 LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO")
 

--- a/tests/test_subscribe_cex_stream.py
+++ b/tests/test_subscribe_cex_stream.py
@@ -19,8 +19,8 @@ async def test_subscribe_cex_stream():
             resp = client.post(
                 "/tools/SubscribeCEXStream",
                 json={
-                    "exchange": "binance",
-                    "symbols": ["BTC/USDT"],
+                    "exchange": "coinbaseexchange",
+                    "symbols": ["BTC/USD"],
                     "interval_sec": 0.1,
                     "max_cycles": 2,
                 },


### PR DESCRIPTION
## Summary
- switch the example exchange from Binance to Coinbase
- default symbols now use BTC/USD
- note Coinbase API vars in README
- update tests for Coinbase

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'temporalio')*

------
https://chatgpt.com/codex/tasks/task_e_6849f1b8e4f48330a6370d60fd339774