### PR TITLE
Fix imports when running agent standalone

### DIFF
--- a/agents/feature_engineering_agent.py
+++ b/agents/feature_engineering_agent.py
@@ -4,10 +4,22 @@ import asyncio
 import logging
 import os
 import signal
+import sys
+from pathlib import Path
 from typing import Any
 
 import aiohttp
 from temporalio.client import Client
+
+
+def _add_project_root_to_path() -> None:
+    """Ensure the repository root is on ``sys.path`` for imports."""
+    root = Path(__file__).resolve().parents[1]
+    if str(root) not in sys.path:
+        sys.path.insert(0, str(root))
+
+
+_add_project_root_to_path()
 from tools.feature_engineering import ComputeFeatureVector
 
 __all__ = ["get_latest_vector", "main"]


### PR DESCRIPTION
## Summary
- ensure project root is on `sys.path` in `feature_engineering_agent`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'temporalio')*

------
https://chatgpt.com/codex/tasks/task_e_684a0306a9b48330932a6f91477ed917