### PR TITLE
Fix Temporal API usage

### DIFF
--- a/agents/feature_engineering_agent.py
+++ b/agents/feature_engineering_agent.py
@@ -101,12 +101,12 @@ async def _store_vector(symbol: str, ts: int, vector: dict) -> None:
 
 async def _signal_tick(client: Client, symbol: str, tick: dict) -> None:
     wf_id = f"feature-{symbol.replace('/', '-') }"
-    await client.signal_with_start_workflow(
+    await client.start_workflow(
         ComputeFeatureVector.run,
         id=wf_id,
         task_queue=TASK_QUEUE,
-        signal="market_tick",
-        signal_args=[tick],
+        start_signal="market_tick",
+        start_signal_args=[tick],
         args=[symbol, 60],
     )
 


### PR DESCRIPTION
## Summary
- use `Client.start_workflow` with start_signal instead of removed `signal_with_start_workflow`

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'temporalio')*

------
https://chatgpt.com/codex/tasks/task_e_684a04cd3bd08330898bf4ad298dce3d