### PR TITLE
Fix segmentation fault by disabling Temporal sandbox

### DIFF
--- a/worker/main.py
+++ b/worker/main.py
@@ -15,6 +15,7 @@ from concurrent.futures import ThreadPoolExecutor
 from temporalio import activity, workflow
 from temporalio.client import Client
 from temporalio.worker import Worker
+from temporalio.worker.workflow_sandbox import UnsandboxedWorkflowRunner
 
 
 def _add_project_root_to_path() -> None:
@@ -73,6 +74,7 @@ async def main() -> None:
             workflows=workflows,
             activities=activities,
             activity_executor=activity_executor,
+            workflow_runner=UnsandboxedWorkflowRunner(),
         )
 
         await worker.run()


### PR DESCRIPTION
## Summary
- run worker using UnsandboxedWorkflowRunner to prevent numpy reload crashes

## Testing
- `python -m pytest -k subscribe_cex_stream -vv` *(fails: ModuleNotFoundError: No module named 'temporalio')*

------
https://chatgpt.com/codex/tasks/task_e_684a070ba330833090143c0073784625