### PR TITLE
Fix UnsandboxedWorkflowRunner import

### DIFF
--- a/worker/main.py
+++ b/worker/main.py
@@ -15,7 +15,10 @@ from concurrent.futures import ThreadPoolExecutor
 from temporalio import activity, workflow
 from temporalio.client import Client
 from temporalio.worker import Worker
-from temporalio.worker.workflow_sandbox import UnsandboxedWorkflowRunner
+# Import UnsandboxedWorkflowRunner from temporalio.worker to ensure
+# compatibility with latest Temporal SDK versions where the class is exported
+# directly from the worker package.
+from temporalio.worker import UnsandboxedWorkflowRunner
 
 
 def _add_project_root_to_path() -> None:


### PR DESCRIPTION
## Summary
- fix outdated import in worker/main.py

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'temporalio')*

------
https://chatgpt.com/codex/tasks/task_e_684a08c4571083308ae6ea4858d42a2a