### PR TITLE
Ignore pytest cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ wheels/
 
 # Virtual environments
 .venv
+.pytest_cache/


### PR DESCRIPTION
## Summary
- ignore `.pytest_cache/` by adding to `.gitignore`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'temporalio')*

------
https://chatgpt.com/codex/tasks/task_e_684a0baa54c083308d3b6ac38d9165d3