### PR TITLE
Add subscribe_vectors helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ Development Workflow
 Create a new tool under tools/ and register it with the MCP server.
 
 Write a strategy agent in agents/ that calls your tool via the MCP client SDK.
+Use `subscribe_vectors(symbol)` from `agents.feature_engineering_agent` to
+stream processed feature rows into your strategy logic.
 
 Unit‑test determinism – run make replay to replay recent workflows.
 


### PR DESCRIPTION
## Summary
- allow other agents to stream feature vectors via `subscribe_vectors`
- simplify momentum agent import
- document vector subscription in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'temporalio')*

------
https://chatgpt.com/codex/tasks/task_e_684a0bafda2083308975d724e18252bc