### PR TITLE
Fix momentum agent import path

### DIFF
--- a/agents/strategies/momentum_agent.py
+++ b/agents/strategies/momentum_agent.py
@@ -6,11 +6,20 @@ import asyncio
 import logging
 import os
 import signal
+import sys
+from pathlib import Path
 from collections import deque
 from datetime import datetime
-from typing import AsyncIterator
 
 import aiohttp
+
+def _add_project_root_to_path() -> None:
+    """Ensure repository root is on ``sys.path`` for imports."""
+    root = Path(__file__).resolve().parents[2]
+    if str(root) not in sys.path:
+        sys.path.insert(0, str(root))
+
+_add_project_root_to_path()
 from agents.feature_engineering_agent import subscribe_vectors
 
 


### PR DESCRIPTION
## Summary
- ensure repo root on `sys.path` for `momentum_agent`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'temporalio')*

------
https://chatgpt.com/codex/tasks/task_e_684a0c93d3d88330afed6585fb93d960