### PR TITLE
Add ensemble agent and signal logging

### DIFF
--- a/agents/ensemble/ensemble_agent.py
+++ b/agents/ensemble/ensemble_agent.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import secrets
+import signal
+from typing import Any, Dict
+
+import aiohttp
+
+from agents.shared_bus import enqueue_intent
+
+MCP_HOST = os.environ.get("MCP_HOST", "localhost")
+MCP_PORT = os.environ.get("MCP_PORT", "8080")
+LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO")
+INTENT_QTY = float(os.environ.get("INTENT_QTY", "1"))
+
+logging.basicConfig(level=LOG_LEVEL, format="[%(asctime)s] %(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+STOP_EVENT = asyncio.Event()
+_latest_price: dict[str, float] = {}
+
+
+async def _fetch(
+    session: aiohttp.ClientSession, url: str, params: Dict[str, Any] | None = None
+) -> Any | None:
+    try:
+        async with session.get(url, params=params) as resp:
+            if resp.status == 200:
+                return await resp.json()
+            logger.warning("GET %s returned %s", url, resp.status)
+    except Exception as exc:
+        logger.error("GET %s failed: %s", url, exc)
+    return None
+
+
+async def _post(session: aiohttp.ClientSession, url: str, json: Dict[str, Any]) -> Any | None:
+    try:
+        async with session.post(url, json=json) as resp:
+            if resp.status in (200, 202, 204):
+                if resp.content_type == "application/json":
+                    return await resp.json()
+                return None
+            logger.warning("POST %s returned %s", url, resp.status)
+    except Exception as exc:
+        logger.error("POST %s failed: %s", url, exc)
+    return None
+
+
+async def _poll_vectors(session: aiohttp.ClientSession) -> None:
+    cursor = 0
+    while not STOP_EVENT.is_set():
+        url = f"http://{MCP_HOST}:{MCP_PORT}/signal/feature_vector"
+        data = await _fetch(session, url, params={"after": cursor})
+        if not data:
+            await asyncio.sleep(1)
+            continue
+        for evt in data:
+            symbol = evt.get("symbol")
+            ts = evt.get("ts")
+            vec = evt.get("data", {})
+            price = vec.get("mid")
+            if symbol and ts and price is not None:
+                _latest_price[symbol] = float(price)
+                cursor = max(cursor, ts)
+        await asyncio.sleep(0)
+
+
+async def _risk_check(session: aiohttp.ClientSession, intent: Dict[str, Any]) -> bool:
+    payload = {"intent_id": secrets.token_hex(8), "intents": [intent]}
+    start = await _post(
+        session, f"http://{MCP_HOST}:{MCP_PORT}/tools/PreTradeRiskCheck", payload
+    )
+    if not start:
+        return False
+    wf_id = start.get("workflow_id")
+    run_id = start.get("run_id")
+    if not wf_id or not run_id:
+        return False
+    while not STOP_EVENT.is_set():
+        await asyncio.sleep(0.5)
+        status = await _fetch(
+            session, f"http://{MCP_HOST}:{MCP_PORT}/workflow/{wf_id}/{run_id}"
+        )
+        if not status:
+            continue
+        state = status.get("status")
+        if state == "COMPLETED":
+            result = status.get("result", {})
+            return result.get("status") == "APPROVED"
+        if state != "RUNNING":
+            logger.error("Risk workflow ended with %s", state)
+            return False
+    return False
+
+
+async def _poll_signals(session: aiohttp.ClientSession) -> None:
+    cursor = 0
+    while not STOP_EVENT.is_set():
+        url = f"http://{MCP_HOST}:{MCP_PORT}/signal/strategy_signal"
+        events = await _fetch(session, url, params={"after": cursor})
+        if not events:
+            await asyncio.sleep(1)
+            continue
+        for evt in events:
+            symbol = evt.get("symbol")
+            side = evt.get("side")
+            ts = evt.get("ts")
+            if not symbol or not side:
+                continue
+            price = _latest_price.get(symbol, 0.0)
+            intent = {
+                "symbol": symbol,
+                "side": side,
+                "qty": INTENT_QTY,
+                "price": price,
+                "ts": ts,
+            }
+            approved = await _risk_check(session, intent)
+            if approved:
+                enqueue_intent(intent)
+                logger.info("Enqueued intent: %s", intent)
+            else:
+                logger.info("Intent rejected: %s", intent)
+            cursor = max(cursor, ts)
+        await asyncio.sleep(0)
+
+
+async def main() -> None:
+    loop = asyncio.get_running_loop()
+    loop.add_signal_handler(signal.SIGINT, STOP_EVENT.set)
+
+    timeout = aiohttp.ClientTimeout(total=30)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        vec_task = asyncio.create_task(_poll_vectors(session))
+        sig_task = asyncio.create_task(_poll_signals(session))
+        await STOP_EVENT.wait()
+        vec_task.cancel()
+        sig_task.cancel()
+        await asyncio.gather(vec_task, sig_task, return_exceptions=True)
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:  # pragma: no cover
+        pass


### PR DESCRIPTION
## Summary
- log strategy signals to the MCP server
- add a new ensemble agent that polls signals, performs pre-trade risk checks and enqueues intents for execution

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'temporalio')*

------
https://chatgpt.com/codex/tasks/task_e_684a13412ea8833090aaf66c93848ba8