### PR TITLE
Fix ensemble agent import

### DIFF
--- a/run_stack.sh
+++ b/run_stack.sh
@@ -84,7 +84,7 @@ tmux send-keys    -t $EXEC_PANE 'sleep 2 && source .venv/bin/activate && python 
 # 9. Pane 8 – ensemble agent (split Pane 7 vertically ↓)
 tmux select-pane  -t $EXEC_PANE
 ENS_PANE=$(tmux split-window -v -P -F "#{pane_id}")
-tmux send-keys    -t $ENS_PANE 'sleep 2 && source .venv/bin/activate && python agents/ensemble/ensemble_agent.py' C-m
+tmux send-keys    -t $ENS_PANE 'sleep 2 && source .venv/bin/activate && python -m agents.ensemble.ensemble_agent' C-m
 
 # 10. Arrange all panes into a tiled layout for equal sizing
 tmux select-layout -t $SESSION:0 tiled


### PR DESCRIPTION
## Summary
- fix relative imports for ensemble agent by invoking with `python -m`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'temporalio')*

------
https://chatgpt.com/codex/tasks/task_e_684a41cb3f0883308c0fa68fe680f5a5