### PR TITLE
Fix subscribe_vectors stop logic

### DIFF
--- a/agents/feature_engineering_agent.py
+++ b/agents/feature_engineering_agent.py
@@ -90,7 +90,7 @@ async def subscribe_vectors(symbol: str) -> AsyncIterator[dict]:
     """Yield feature vectors for ``symbol`` as they arrive."""
 
     last_ts = 0
-    while True:
+    while not STOP_EVENT.is_set():
         async with _FEATURE_LOCK:
             items = sorted(
                 [
@@ -104,6 +104,8 @@ async def subscribe_vectors(symbol: str) -> AsyncIterator[dict]:
             await asyncio.sleep(0.1)
             continue
         for ts, vec in items:
+            if STOP_EVENT.is_set():
+                return
             last_ts = ts
             yield vec
 

--- a/tests/test_subscribe_vectors_stop.py
+++ b/tests/test_subscribe_vectors_stop.py
@@ -1,0 +1,27 @@
+import pytest
+
+from agents.feature_engineering_agent import (
+    subscribe_vectors,
+    STOP_EVENT,
+    _store_vector,
+    FEATURE_STORE,
+)
+
+
+@pytest.mark.asyncio
+async def test_subscribe_vectors_respects_stop_event():
+    # ensure clean state
+    FEATURE_STORE.clear()
+    STOP_EVENT.clear()
+
+    await _store_vector("BTC/USD", 1, {"foo": "bar"})
+    gen = subscribe_vectors("BTC/USD")
+
+    first = await anext(gen)
+    assert first == {"foo": "bar"}
+
+    STOP_EVENT.set()
+    with pytest.raises(StopAsyncIteration):
+        await anext(gen)
+
+    STOP_EVENT.clear()


### PR DESCRIPTION
## Summary
- break out of subscribe_vectors when STOP_EVENT is set
- add regression test for STOP_EVENT handling

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'temporalio')*

------
https://chatgpt.com/codex/tasks/task_e_684a5f2ce2288330aff4d37345d33c7b