### PR TITLE
Fix momentum agent freeze by polling vectors over HTTP

### DIFF
--- a/agents/strategies/momentum_agent.py
+++ b/agents/strategies/momentum_agent.py
@@ -124,7 +124,7 @@ async def main() -> None:
 
     timeout = aiohttp.ClientTimeout(total=30)
     async with aiohttp.ClientSession(timeout=timeout) as session:
-        async for vector in subscribe_vectors(SYMBOL):
+        async for vector in subscribe_vectors(SYMBOL, use_local=False):
             if STOP_EVENT.is_set():
                 break
             vec_queue.append(vector)

--- a/tests/test_subscribe_vectors_stop.py
+++ b/tests/test_subscribe_vectors_stop.py
@@ -15,7 +15,7 @@ async def test_subscribe_vectors_respects_stop_event():
     STOP_EVENT.clear()
 
     await _store_vector("BTC/USD", 1, {"foo": "bar"})
-    gen = subscribe_vectors("BTC/USD")
+    gen = subscribe_vectors("BTC/USD", use_local=True)
 
     first = await anext(gen)
     assert first == {"foo": "bar"}


### PR DESCRIPTION
## Summary
- allow `subscribe_vectors` to stream data from the MCP server
- consume remote vectors in `momentum_agent`
- adapt test to use local feature store

## Testing
- `python -m py_compile agents/feature_engineering_agent.py agents/strategies/momentum_agent.py tests/test_subscribe_vectors_stop.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'temporalio')*

------
https://chatgpt.com/codex/tasks/task_e_684a62718e9483309ff4419413041e74