### PR TITLE
Adjust momentum thresholds

### DIFF
--- a/agents/feature_engineering_agent.py
+++ b/agents/feature_engineering_agent.py
@@ -39,6 +39,7 @@ LOG_EVERY = int(os.environ.get("LOG_EVERY", "10"))
 TEMPORAL_ADDRESS = os.environ.get("TEMPORAL_ADDRESS", "localhost:7233")
 TEMPORAL_NAMESPACE = os.environ.get("TEMPORAL_NAMESPACE", "default")
 TASK_QUEUE = os.environ.get("TASK_QUEUE", "mcp-tools")
+FEATURE_WINDOW_SEC = int(os.environ.get("VECTOR_WINDOW_SEC", "300"))
 
 STOP_EVENT = asyncio.Event()
 TASKS: set[asyncio.Task[Any]] = set()
@@ -173,7 +174,7 @@ async def _signal_tick(client: Client, symbol: str, tick: dict) -> None:
         task_queue=TASK_QUEUE,
         start_signal="market_tick",
         start_signal_args=[tick],
-        args=[symbol, 60],
+        args=[symbol, FEATURE_WINDOW_SEC],
     )
 
 


### PR DESCRIPTION
## Summary
- expose SMA window durations via env vars
- retain enough ticks for the long SMA

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'temporalio')*

------
https://chatgpt.com/codex/tasks/task_e_684a64b02b2c8330b1b5a833e9a99ba3