### PR TITLE
Refactor agents to Temporal workflows

### DIFF
--- a/agents/workflows.py
+++ b/agents/workflows.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from collections import deque
+from datetime import datetime
+from decimal import Decimal
+from typing import Dict, List, Tuple
+
+from temporalio import workflow
+
+
+@workflow.defn
+class FeatureStoreWorkflow:
+    """Persist feature vectors signalled from agents."""
+
+    def __init__(self) -> None:
+        self.store: Dict[Tuple[str, int], Dict] = {}
+        self.count = 0
+
+    @workflow.signal
+    def add_vector(self, symbol: str, ts: int, data: Dict) -> None:
+        self.store[(symbol, ts)] = data
+        self.count += 1
+
+    @workflow.query
+    def latest_vector(self, symbol: str) -> Dict | None:
+        matches = [(ts, vec) for (sym, ts), vec in self.store.items() if sym == symbol]
+        if not matches:
+            return None
+        ts, vec = max(matches, key=lambda kv: kv[0])
+        return vec
+
+    @workflow.query
+    def next_vector(self, symbol: str, after_ts: int) -> Tuple[int, Dict] | None:
+        items = sorted(
+            [(ts, v) for (sym, ts), v in self.store.items() if sym == symbol and ts > after_ts],
+            key=lambda kv: kv[0],
+        )
+        if not items:
+            return None
+        ts, vec = items[0]
+        return ts, vec
+
+    @workflow.run
+    async def run(self) -> None:
+        await workflow.wait_condition(lambda: False)
+
+
+@workflow.defn
+class EnsembleWorkflow:
+    """Store latest prices and approved intents."""
+
+    def __init__(self) -> None:
+        self.latest_price: Dict[str, float] = {}
+        self.intents: List[Dict] = []
+
+    @workflow.signal
+    def update_price(self, symbol: str, price: float) -> None:
+        self.latest_price[symbol] = price
+
+    @workflow.signal
+    def record_intent(self, intent: Dict) -> None:
+        self.intents.append(intent)
+
+    @workflow.query
+    def get_price(self, symbol: str) -> float | None:
+        return self.latest_price.get(symbol)
+
+    @workflow.query
+    def get_intents(self) -> List[Dict]:
+        return list(self.intents)
+
+    @workflow.run
+    async def run(self) -> None:
+        await workflow.wait_condition(lambda: False)
+
+
+@workflow.defn
+class MomentumWorkflow:
+    """Detect SMA crossovers from feature vectors."""
+
+    def __init__(self) -> None:
+        self.vectors: deque[Dict] = deque(maxlen=2)
+        self.signals: List[Dict] = []
+        self.cooldown = 30
+        self.last_sent = 0
+
+    @workflow.signal
+    def add_vector(self, vector: Dict) -> None:
+        self.vectors.append(vector)
+
+    @workflow.query
+    def next_signal(self, after_ts: int) -> Dict | None:
+        items = [s for s in self.signals if s["ts"] > after_ts]
+        return items[0] if items else None
+
+    @staticmethod
+    def _cross(prev: Dict, curr: Dict) -> str | None:
+        p1, p5 = prev.get("sma1"), prev.get("sma5")
+        c1, c5 = curr.get("sma1"), curr.get("sma5")
+        if None in (p1, p5, c1, c5):
+            return None
+        if p1 < p5 and c1 > c5:
+            return "BUY"
+        if p1 > p5 and c1 < c5:
+            return "SELL"
+        return None
+
+    @workflow.run
+    async def run(self, cooldown: int = 30) -> None:
+        self.cooldown = cooldown
+        while True:
+            await workflow.wait_condition(lambda: len(self.vectors) == 2)
+            prev, curr = self.vectors[0], self.vectors[1]
+            side = self._cross(prev, curr)
+            if not side:
+                self.vectors.popleft()
+                continue
+            now = int(datetime.utcnow().timestamp())
+            if now - self.last_sent < self.cooldown:
+                self.vectors.popleft()
+                continue
+            self.last_sent = now
+            self.signals.append({"side": side, "ts": now})
+            self.vectors.popleft()
+
+
+@workflow.defn
+class ExecutionLedgerWorkflow:
+    """Maintain mock execution ledger state."""
+
+    def __init__(self) -> None:
+        self.cash = Decimal("20")
+        self.positions: Dict[str, Decimal] = {}
+        self.last_price: Dict[str, Decimal] = {}
+        self.fill_count = 0
+
+    @workflow.signal
+    def record_fill(self, fill: Dict) -> None:
+        side = fill["side"]
+        symbol = fill["symbol"]
+        qty = Decimal(str(fill["qty"]))
+        price = Decimal(str(fill["fill_price"]))
+        cost = Decimal(str(fill["cost"]))
+        self.last_price[symbol] = price
+        if side == "BUY":
+            self.cash -= cost
+            self.positions[symbol] = self.positions.get(symbol, Decimal("0")) + qty
+        else:
+            self.cash += cost
+            self.positions[symbol] = self.positions.get(symbol, Decimal("0")) - qty
+        self.fill_count += 1
+
+    @workflow.query
+    def get_pnl(self) -> float:
+        pnl = self.cash + sum(
+            q * self.last_price.get(sym, Decimal("0")) for sym, q in self.positions.items()
+        )
+        return float(pnl)
+
+    @workflow.query
+    def get_cash(self) -> float:
+        return float(self.cash)
+
+    @workflow.run
+    async def run(self) -> None:
+        await workflow.wait_condition(lambda: False)

--- a/tests/test_subscribe_vectors_stop.py
+++ b/tests/test_subscribe_vectors_stop.py
@@ -4,14 +4,11 @@ from agents.feature_engineering_agent import (
     subscribe_vectors,
     STOP_EVENT,
     _store_vector,
-    FEATURE_STORE,
 )
 
 
 @pytest.mark.asyncio
 async def test_subscribe_vectors_respects_stop_event():
-    # ensure clean state
-    FEATURE_STORE.clear()
     STOP_EVENT.clear()
 
     await _store_vector("BTC/USD", 1, {"foo": "bar"})


### PR DESCRIPTION
## Summary
- create new workflow classes for agent state
- refactor feature engineering agent to store vectors in workflow
- update ensemble agent to record prices and intents in workflow
- move momentum agent logic into workflow-backed signalling
- track execution ledger state in workflow
- adjust existing tests for new APIs

## Testing
- `pytest -q` *(fails: ImportError for `docker_service`)*

------
https://chatgpt.com/codex/tasks/task_e_684a716552e48330a8bad49eb5633a58