### PR TITLE
Fix workflow handling and add tests

### DIFF
--- a/agents/ensemble/ensemble_agent.py
+++ b/agents/ensemble/ensemble_agent.py
@@ -11,7 +11,7 @@ import aiohttp
 
 from agents.shared_bus import enqueue_intent
 from agents.workflows import EnsembleWorkflow
-from temporalio.client import Client
+from temporalio.client import Client, WorkflowNotFoundError
 
 MCP_HOST = os.environ.get("MCP_HOST", "localhost")
 MCP_PORT = os.environ.get("MCP_PORT", "8080")
@@ -36,9 +36,10 @@ async def _get_client() -> Client:
 
 
 async def _ensure_workflow(client: Client) -> None:
+    handle = client.get_workflow_handle(ENSEMBLE_WF_ID)
     try:
-        await client.get_workflow_handle(ENSEMBLE_WF_ID)
-    except Exception:
+        await handle.describe()
+    except WorkflowNotFoundError:
         await client.start_workflow(
             EnsembleWorkflow.run,
             id=ENSEMBLE_WF_ID,

--- a/agents/execution/mock_exec_agent.py
+++ b/agents/execution/mock_exec_agent.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from decimal import Decimal
 
 import aiohttp
-from temporalio.client import Client
+from temporalio.client import Client, WorkflowNotFoundError
 from agents.workflows import ExecutionLedgerWorkflow
 
 try:
@@ -39,9 +39,10 @@ async def _get_client() -> Client:
 
 
 async def _ensure_workflow(client: Client) -> None:
+    handle = client.get_workflow_handle(LEDGER_WF_ID)
     try:
-        await client.get_workflow_handle(LEDGER_WF_ID)
-    except Exception:
+        await handle.describe()
+    except WorkflowNotFoundError:
         await client.start_workflow(
             ExecutionLedgerWorkflow.run,
             id=LEDGER_WF_ID,

--- a/agents/feature_engineering_agent.py
+++ b/agents/feature_engineering_agent.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any, AsyncIterator
 
 import aiohttp
-from temporalio.client import Client
+from temporalio.client import Client, WorkflowNotFoundError
 
 from agents.workflows import FeatureStoreWorkflow
 
@@ -89,9 +89,10 @@ async def _get_client() -> Client:
 
 
 async def _ensure_workflow(client: Client) -> None:
+    handle = client.get_workflow_handle(FEATURE_WF_ID)
     try:
-        await client.get_workflow_handle(FEATURE_WF_ID)
-    except Exception:
+        await handle.describe()
+    except WorkflowNotFoundError:
         await client.start_workflow(
             FeatureStoreWorkflow.run,
             id=FEATURE_WF_ID,

--- a/agents/strategies/momentum_agent.py
+++ b/agents/strategies/momentum_agent.py
@@ -24,7 +24,7 @@ def _add_project_root_to_path() -> None:
 _add_project_root_to_path()
 from agents.feature_engineering_agent import subscribe_vectors  # noqa: E402
 from agents.workflows import MomentumWorkflow
-from temporalio.client import Client
+from temporalio.client import Client, WorkflowNotFoundError
 
 
 logger = logging.getLogger(__name__)
@@ -55,9 +55,10 @@ async def _get_client() -> Client:
 
 
 async def _ensure_workflow(client: Client) -> None:
+    handle = client.get_workflow_handle(MOMENTUM_WF_ID)
     try:
-        await client.get_workflow_handle(MOMENTUM_WF_ID)
-    except Exception:
+        await handle.describe()
+    except WorkflowNotFoundError:
         await client.start_workflow(
             MomentumWorkflow.run,
             id=MOMENTUM_WF_ID,

--- a/tests/test_ensure_workflows.py
+++ b/tests/test_ensure_workflows.py
@@ -1,0 +1,30 @@
+import asyncio
+import os
+
+import pytest
+from temporalio.testing import docker_service
+from temporalio.client import Client
+
+from agents.feature_engineering_agent import _ensure_workflow as ensure_feature, FEATURE_WF_ID
+from agents.ensemble.ensemble_agent import _ensure_workflow as ensure_ensemble, ENSEMBLE_WF_ID
+from agents.strategies.momentum_agent import _ensure_workflow as ensure_momentum, MOMENTUM_WF_ID
+from agents.execution.mock_exec_agent import _ensure_workflow as ensure_ledger, LEDGER_WF_ID
+
+
+@pytest.mark.asyncio
+async def test_agents_auto_start_workflows():
+    async with docker_service() as svc:
+        os.environ["TEMPORAL_ADDRESS"] = f"{svc.target_host}:{svc.grpc_port}"
+        os.environ["TEMPORAL_NAMESPACE"] = svc.namespace
+        client = await Client.connect(os.environ["TEMPORAL_ADDRESS"], namespace=os.environ["TEMPORAL_NAMESPACE"])
+
+        for ensure, wf_id in [
+            (ensure_feature, FEATURE_WF_ID),
+            (ensure_ensemble, ENSEMBLE_WF_ID),
+            (ensure_momentum, MOMENTUM_WF_ID),
+            (ensure_ledger, LEDGER_WF_ID),
+        ]:
+            await ensure(client)
+            handle = client.get_workflow_handle(wf_id)
+            desc = await handle.describe()
+            assert desc.workflow_id == wf_id


### PR DESCRIPTION
## Summary
- update agents to check workflow existence using `describe`
- start workflow only when missing
- ensure all agents share this logic
- test auto-start behavior for each agent

## Testing
- `pytest -q` *(fails: ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_684a7dd2df948330b534094379abfa5a