### PR TITLE
Fix kw-only param error in SubscribeCEXStream

### DIFF
--- a/tools/market_data.py
+++ b/tools/market_data.py
@@ -61,7 +61,6 @@ class SubscribeCEXStream:
         symbols: List[str],
         interval_sec: int = 1,
         max_cycles: int | None = None,
-        *,
         continue_every: int = STREAM_CONTINUE_EVERY,
     ) -> None:
         """Stream tickers indefinitely, continuing as new periodically."""


### PR DESCRIPTION
## Summary
- make `continue_every` positional in `SubscribeCEXStream.run`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'temporalio')*

------
https://chatgpt.com/codex/tasks/task_e_684a835a6a70833085efb4da1d548696