### PR TITLE
Handle unexpected errors in ensemble polling

### DIFF
--- a/agents/ensemble/ensemble_agent.py
+++ b/agents/ensemble/ensemble_agent.py
@@ -121,6 +121,8 @@ async def _poll_vectors(session: aiohttp.ClientSession) -> None:
                         err.status,
                         err.message,
                     )
+                except Exception:  # pragma: no cover - unexpected errors
+                    logger.exception("Unexpected error updating price")
         await asyncio.sleep(0)
 
 
@@ -199,6 +201,8 @@ async def _poll_signals(session: aiohttp.ClientSession) -> None:
                     err.status,
                     err.message,
                 )
+            except Exception:  # pragma: no cover - unexpected errors
+                logger.exception("Unexpected error processing intent")
         await asyncio.sleep(0)
 
 

--- a/tests/test_ensemble_rpc_error.py
+++ b/tests/test_ensemble_rpc_error.py
@@ -53,6 +53,50 @@ async def test_poll_vectors_logs_rpc_error_and_continues(monkeypatch, caplog):
     assert "RPC error" in caplog.text
 
 
+class DummyHandleExc:
+    def __init__(self):
+        self.signal_calls = 0
+
+    async def signal(self, *args, **kwargs):
+        self.signal_calls += 1
+        raise ValueError("boom")
+
+
+class DummyClientExc:
+    def __init__(self):
+        self.handle = DummyHandleExc()
+
+    def get_workflow_handle(self, wf_id: str):
+        return self.handle
+
+
+async def fake_get_client_exc():
+    return DummyClientExc()
+
+
+@pytest.mark.asyncio
+async def test_poll_vectors_logs_unexpected_error_and_continues(monkeypatch, caplog):
+    calls = {"count": 0}
+
+    async def fake_fetch(_session, _url, *, params=None):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return [{"symbol": "BTC/USD", "ts": 1, "data": {"mid": 1.0}}]
+        ea.STOP_EVENT.set()
+        return []
+
+    monkeypatch.setattr(ea, "_fetch", fake_fetch)
+    monkeypatch.setattr(ea, "_get_client", fake_get_client_exc)
+    monkeypatch.setattr(ea, "_ensure_workflow", fake_ensure)
+    ea.STOP_EVENT.clear()
+
+    with caplog.at_level(logging.ERROR):
+        await ea._poll_vectors(None)
+
+    assert calls["count"] >= 2
+    assert "Unexpected error updating price" in caplog.text
+
+
 class DummyQueryHandle:
     def __init__(self):
         self.query_calls = 0
@@ -110,3 +154,54 @@ async def test_poll_signals_logs_rpc_error_and_continues(monkeypatch, caplog):
 
     assert calls["count"] >= 2
     assert "RPC error" in caplog.text
+
+
+class DummyQueryHandleExc:
+    def __init__(self):
+        self.query_calls = 0
+        self.signal_calls = 0
+
+    async def query(self, *args, **kwargs):
+        self.query_calls += 1
+        raise ValueError("boom")
+
+    async def signal(self, *args, **kwargs):
+        self.signal_calls += 1
+        return None
+
+
+class DummyQueryClientExc:
+    def __init__(self):
+        self.handle = DummyQueryHandleExc()
+
+    def get_workflow_handle(self, wf_id: str):
+        return self.handle
+
+
+async def fake_get_client_sig_exc():
+    return DummyQueryClientExc()
+
+
+@pytest.mark.asyncio
+async def test_poll_signals_logs_unexpected_error_and_continues(monkeypatch, caplog):
+    calls = {"count": 0}
+
+    async def fake_fetch(_session, _url, *, params=None):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return [{"symbol": "BTC/USD", "side": "BUY", "ts": 1}]
+        ea.STOP_EVENT.set()
+        return []
+
+    monkeypatch.setattr(ea, "_fetch", fake_fetch)
+    monkeypatch.setattr(ea, "_get_client", fake_get_client_sig_exc)
+    monkeypatch.setattr(ea, "_ensure_workflow", fake_ensure)
+    monkeypatch.setattr(ea, "_risk_check", fake_risk_check)
+    monkeypatch.setattr(ea, "_broadcast_intent", fake_broadcast)
+    ea.STOP_EVENT.clear()
+
+    with caplog.at_level(logging.ERROR):
+        await ea._poll_signals(None)
+
+    assert calls["count"] >= 2
+    assert "Unexpected error processing intent" in caplog.text


### PR DESCRIPTION
## Summary
- handle generic exceptions in ensemble polling loops
- extend coverage for `_poll_vectors` and `_poll_signals` when unexpected errors occur

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'temporalio')*

------
https://chatgpt.com/codex/tasks/task_e_684af548eba88330b49d9900a459edf1