### PR TITLE
Fix run_stack broker agent

### DIFF
--- a/run_stack.sh
+++ b/run_stack.sh
@@ -69,7 +69,7 @@ tmux select-layout -t $SESSION:0 tiled
 # 6. Pane 5 – broker agent (split Pane 4 horizontally ←)
 tmux select-pane  -t $MOM_PANE
 BROKER_PANE=$(tmux split-window -h -P -F "#{pane_id}")
-tmux send-keys    -t $BROKER_PANE 'sleep 3 && source .venv/bin/activate && python agents/broker_agent.py'
+tmux send-keys    -t $BROKER_PANE 'sleep 3 && source .venv/bin/activate && python agents/broker_agent.py' C-m
 
 # 7. Pane 6 – blank shell (split Pane 5 vertically ↓)
 tmux select-pane  -t $BROKER_PANE


### PR DESCRIPTION
## Summary
- add missing Enter keystroke when starting broker agent

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'temporalio')*

------
https://chatgpt.com/codex/tasks/task_e_684b028d5e888330bce4d923dc37c385