### PR TITLE
Enhance broker agent with portfolio status command

### DIFF
--- a/agents/workflows.py
+++ b/agents/workflows.py
@@ -161,6 +161,11 @@ class ExecutionLedgerWorkflow:
     def get_cash(self) -> float:
         return float(self.cash)
 
+    @workflow.query
+    def get_positions(self) -> Dict[str, float]:
+        """Return current position sizes as floats."""
+        return {sym: float(q) for sym, q in self.positions.items()}
+
     @workflow.run
     async def run(self) -> None:
         await workflow.wait_condition(lambda: False)


### PR DESCRIPTION
## Summary
- keep the broker chat open after starting the data stream
- allow users to request portfolio status
- expose `get_positions` query on `ExecutionLedgerWorkflow`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'temporalio')*

------
https://chatgpt.com/codex/tasks/task_e_684b08c59bf88330808fda6bc7dd269d