### PR TITLE
Enable continue-as-new for feature workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ If Binance is blocked in your region, pass `"exchange": "coinbaseexchange"` when
 mechanism after a configurable number of cycles to prevent unbounded workflow
 history growth. The default interval is one hour (3600 cycles) and can be
 changed by setting the `STREAM_CONTINUE_EVERY` environment variable.
+`ComputeFeatureVector` behaves the same way using the `VECTOR_CONTINUE_EVERY`
+environment variable.
 
 ## Development Workflow
 - Create a new tool under `tools/` and register it with the MCP server.

--- a/agents/feature_engineering_agent.py
+++ b/agents/feature_engineering_agent.py
@@ -43,6 +43,7 @@ TEMPORAL_ADDRESS = os.environ.get("TEMPORAL_ADDRESS", "localhost:7233")
 TEMPORAL_NAMESPACE = os.environ.get("TEMPORAL_NAMESPACE", "default")
 TASK_QUEUE = os.environ.get("TASK_QUEUE", "mcp-tools")
 FEATURE_WINDOW_SEC = int(os.environ.get("VECTOR_WINDOW_SEC", "300"))
+VECTOR_CONTINUE_EVERY = int(os.environ.get("VECTOR_CONTINUE_EVERY", "3600"))
 
 STOP_EVENT = asyncio.Event()
 TASKS: set[asyncio.Task[Any]] = set()
@@ -184,7 +185,7 @@ async def _signal_tick(client: Client, symbol: str, tick: dict) -> None:
         task_queue=TASK_QUEUE,
         start_signal="market_tick",
         start_signal_args=[tick],
-        args=[symbol, FEATURE_WINDOW_SEC],
+        args=[symbol, FEATURE_WINDOW_SEC, VECTOR_CONTINUE_EVERY],
     )
 
 


### PR DESCRIPTION
## Summary
- limit history size for ComputeFeatureVector with Continue As New
- pass the new parameter from feature agent
- document `VECTOR_CONTINUE_EVERY`

## Testing
- `make lint test` *(fails: No rule to make target 'lint')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'temporalio')*

------
https://chatgpt.com/codex/tasks/task_e_684b1057864c8330b29c99660a4f42c5