### PR TITLE
Fix sell order validation

### DIFF
--- a/agents/execution/mock_exec_agent.py
+++ b/agents/execution/mock_exec_agent.py
@@ -82,9 +82,14 @@ async def _place_order(session: aiohttp.ClientSession, intent: dict) -> None:
     await _ensure_workflow(client)
     handle = client.get_workflow_handle(LEDGER_WF_ID)
     cash = await handle.query("get_cash")
+    positions = await handle.query("get_positions")
+    pos_qty = Decimal(str(positions.get(intent["symbol"], 0)))
 
     if intent["side"] == "BUY" and Decimal(str(cash)) < cost:
         logger.warning("INSUFFICIENT_FUNDS for %s", intent)
+        return
+    if intent["side"] == "SELL" and pos_qty < qty:
+        logger.warning("INSUFFICIENT_POSITION for %s", intent)
         return
 
     try:

--- a/tests/test_sell_validation.py
+++ b/tests/test_sell_validation.py
@@ -1,0 +1,39 @@
+import pytest
+
+from agents.execution import mock_exec_agent as mea
+
+class DummyHandle:
+    async def query(self, what):
+        if what == "get_cash":
+            return 1000.0
+        if what == "get_positions":
+            return {}
+
+class DummyClient:
+    def get_workflow_handle(self, wf_id):
+        return DummyHandle()
+
+aSYNC_CLIENT = DummyClient()
+
+async def fake_get_client():
+    return aSYNC_CLIENT
+
+async def fake_ensure(_):
+    return None
+
+class DummySession:
+    def __init__(self):
+        self.post_called = False
+    async def post(self, *args, **kwargs):
+        self.post_called = True
+    async def get(self, *args, **kwargs):
+        return None
+
+@pytest.mark.asyncio
+async def test_sell_with_no_position_skips_order(monkeypatch):
+    monkeypatch.setattr(mea, "_get_client", fake_get_client)
+    monkeypatch.setattr(mea, "_ensure_workflow", fake_ensure)
+    sess = DummySession()
+    intent = {"side": "SELL", "symbol": "BTC/USD", "qty": 1, "price": 10}
+    await mea._place_order(sess, intent)
+    assert not sess.post_called


### PR DESCRIPTION
## Summary
- prevent sells without holdings by tracking positions in `mock_exec_agent`
- add unit test for sell constraint

## Testing
- `pytest -q tests/test_sell_validation.py` *(fails: ModuleNotFoundError: No module named 'aiohttp')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'temporalio')*

------
https://chatgpt.com/codex/tasks/task_e_684b12400ea4833090879d87c0539a52