### PR TITLE
Fix ledger PnL calculation

### DIFF
--- a/agents/workflows.py
+++ b/agents/workflows.py
@@ -129,6 +129,7 @@ class ExecutionLedgerWorkflow:
     """Maintain mock execution ledger state."""
 
     def __init__(self) -> None:
+        self.initial_cash = Decimal("250000")
         self.cash = Decimal("250000")
         self.positions: Dict[str, Decimal] = {}
         self.last_price: Dict[str, Decimal] = {}
@@ -152,9 +153,11 @@ class ExecutionLedgerWorkflow:
 
     @workflow.query
     def get_pnl(self) -> float:
-        pnl = self.cash + sum(
-            q * self.last_price.get(sym, Decimal("0")) for sym, q in self.positions.items()
+        position_value = sum(
+            q * self.last_price.get(sym, Decimal("0"))
+            for sym, q in self.positions.items()
         )
+        pnl = (self.cash + position_value) - self.initial_cash
         return float(pnl)
 
     @workflow.query

--- a/tests/test_ledger_pnl.py
+++ b/tests/test_ledger_pnl.py
@@ -1,0 +1,19 @@
+import pytest
+from agents.workflows import ExecutionLedgerWorkflow
+from decimal import Decimal
+
+
+def test_pnl_uses_initial_cash_and_unrealized_value():
+    wf = ExecutionLedgerWorkflow()
+    assert wf.get_pnl() == 0.0
+    wf.record_fill({
+        "side": "BUY",
+        "symbol": "BTC/USD",
+        "qty": 10,
+        "fill_price": 1000,
+        "cost": 10000,
+    })
+    assert wf.get_pnl() == 0.0
+    wf.last_price["BTC/USD"] = Decimal("1100")
+    assert wf.get_pnl() == pytest.approx(1000.0)
+


### PR DESCRIPTION
## Summary
- track `initial_cash` in the mock execution ledger
- compute PnL relative to starting cash
- add regression test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'temporalio')*

------
https://chatgpt.com/codex/tasks/task_e_684b1598fd5c8330851758c12af8aa16