### PR TITLE
Fix risk workflow invocation

### DIFF
--- a/agents/ensemble/ensemble_agent.py
+++ b/agents/ensemble/ensemble_agent.py
@@ -134,8 +134,8 @@ async def _risk_check(_session: aiohttp.ClientSession | None, intent: Dict[str, 
     try:
         handle = await client.start_workflow(
             PreTradeRiskCheck.run,
-            intent_id=wf_id,
-            intents=[intent],
+            wf_id,
+            [intent],
             id=wf_id,
             task_queue=os.environ.get("TASK_QUEUE", "mcp-tools"),
         )


### PR DESCRIPTION
## Summary
- fix passing parameters to PreTradeRiskCheck

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'docker_service')*

------
https://chatgpt.com/codex/tasks/task_e_684b1bd2a72c8330a922fd30abfbf3ea