### PR TITLE
Fix risk workflow startup

### DIFF
--- a/agents/ensemble/ensemble_agent.py
+++ b/agents/ensemble/ensemble_agent.py
@@ -134,8 +134,7 @@ async def _risk_check(_session: aiohttp.ClientSession | None, intent: Dict[str, 
     try:
         handle = await client.start_workflow(
             PreTradeRiskCheck.run,
-            wf_id,
-            [intent],
+            args=[wf_id, [intent]],
             id=wf_id,
             task_queue=os.environ.get("TASK_QUEUE", "mcp-tools"),
         )


### PR DESCRIPTION
## Summary
- ensure `PreTradeRiskCheck` workflow is started with multiple args passed correctly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'temporalio')*

------
https://chatgpt.com/codex/tasks/task_e_684b1e935a448330aaf8a31ab6e3b57c