### PR TITLE
Add agent startup banners

### DIFF
--- a/agents/broker_agent.py
+++ b/agents/broker_agent.py
@@ -9,6 +9,7 @@ from typing import List, Dict
 from temporalio.client import Client
 from temporalio.service import RPCError, RPCStatusCode
 from agents.workflows import ExecutionLedgerWorkflow
+from agents.utils import print_banner
 
 import aiohttp
 
@@ -202,6 +203,11 @@ async def _chat_loop(messages: list[dict]) -> None:
 
 
 async def main() -> None:
+    print_banner(
+        "Broker Agent",
+        "Interactively start market data streams",
+    )
+
     symbols, messages = await _prompt_user()
     if not symbols:
         return

--- a/agents/ensemble/ensemble_agent.py
+++ b/agents/ensemble/ensemble_agent.py
@@ -14,6 +14,7 @@ from agents.shared_bus import enqueue_intent
 from agents.workflows import EnsembleWorkflow
 from tools.intent_bus import IntentBus
 from tools.risk import PreTradeRiskCheck
+from agents.utils import print_banner
 from temporalio.client import Client
 from temporalio.service import RPCError, RPCStatusCode
 
@@ -198,6 +199,11 @@ async def _poll_signals(session: aiohttp.ClientSession) -> None:
 
 
 async def main() -> None:
+    print_banner(
+        "Ensemble Agent",
+        "Aggregate signals and broadcast intents",
+    )
+
     loop = asyncio.get_running_loop()
     loop.add_signal_handler(signal.SIGINT, STOP_EVENT.set)
 

--- a/agents/execution/mock_exec_agent.py
+++ b/agents/execution/mock_exec_agent.py
@@ -12,6 +12,7 @@ from temporalio.client import Client
 from temporalio.service import RPCError, RPCStatusCode
 from agents.workflows import ExecutionLedgerWorkflow
 from tools.execution import PlaceMockOrder
+from agents.utils import print_banner
 
 try:
     from agents.shared_bus import APPROVED_INTENT_QUEUE
@@ -142,6 +143,11 @@ async def _run() -> None:
 
 
 async def main() -> None:
+    print_banner(
+        "Mock Execution Agent",
+        "Simulate order execution",
+    )
+
     loop = asyncio.get_running_loop()
     loop.add_signal_handler(signal.SIGINT, STOP_EVENT.set)
     try:

--- a/agents/feature_engineering_agent.py
+++ b/agents/feature_engineering_agent.py
@@ -13,6 +13,7 @@ from temporalio.client import Client
 from temporalio.service import RPCError, RPCStatusCode
 
 from agents.workflows import FeatureStoreWorkflow
+from agents.utils import print_banner
 
 
 def _add_project_root_to_path() -> None:
@@ -230,6 +231,11 @@ async def _shutdown() -> None:
 
 async def main() -> None:
     """Run the feature engineering agent."""
+
+    print_banner(
+        "Feature Engineering Agent",
+        "Compute and store feature vectors",
+    )
 
     loop = asyncio.get_running_loop()
     loop.add_signal_handler(signal.SIGINT, STOP_EVENT.set)

--- a/agents/strategies/momentum_agent.py
+++ b/agents/strategies/momentum_agent.py
@@ -24,6 +24,7 @@ def _add_project_root_to_path() -> None:
 _add_project_root_to_path()
 from agents.feature_engineering_agent import subscribe_vectors  # noqa: E402
 from agents.workflows import MomentumWorkflow  # noqa: E402
+from agents.utils import print_banner
 from temporalio.client import Client  # noqa: E402
 from temporalio.service import RPCError, RPCStatusCode  # noqa: E402
 
@@ -163,6 +164,11 @@ async def _run_tool(session: aiohttp.ClientSession, payload: dict) -> None:
 
 async def main() -> None:
     """Run the momentum strategy agent."""
+    print_banner(
+        "Momentum Strategy Agent",
+        "Emit buy/sell signals via SMA crossover",
+    )
+
     loop = asyncio.get_running_loop()
     loop.add_signal_handler(signal.SIGINT, _handle_sigint)
 

--- a/agents/utils.py
+++ b/agents/utils.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+
+def print_banner(name: str, purpose: str) -> None:
+    """Print a simple ASCII banner with ``name`` and ``purpose``."""
+    lines = [name, purpose]
+    width = max(len(line) for line in lines) + 4
+    border = "*" * width
+    print(border)
+    for line in lines:
+        print(f"* {line.ljust(width - 4)} *")
+    print(border)
+
+__all__ = ["print_banner"]
+


### PR DESCRIPTION
## Summary
- show a banner at startup for each agent
- implement banner helper in `agents.utils`

## Testing
- `python -m py_compile agents/utils.py agents/feature_engineering_agent.py agents/broker_agent.py agents/ensemble/ensemble_agent.py agents/execution/mock_exec_agent.py agents/strategies/momentum_agent.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'temporalio')*

------
https://chatgpt.com/codex/tasks/task_e_684b2dd778d08330ac0f59289f8c655f