### PR TITLE
Add history-based continue-as-new

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,9 +118,11 @@ If Binance is blocked in your region, pass `"exchange": "coinbaseexchange"` when
 `SubscribeCEXStream` automatically restarts itself via Temporal's *continue as new*
 mechanism after a configurable number of cycles to prevent unbounded workflow
 history growth. The default interval is one hour (3600 cycles) and can be
-changed by setting the `STREAM_CONTINUE_EVERY` environment variable.
+changed by setting the `STREAM_CONTINUE_EVERY` environment variable. The workflow
+also checks its current history length and continues early when it exceeds
+`STREAM_HISTORY_LIMIT` (defaults to 9000 events).
 `ComputeFeatureVector` behaves the same way using the `VECTOR_CONTINUE_EVERY`
-environment variable.
+and `VECTOR_HISTORY_LIMIT` environment variables.
 
 ## Development Workflow
 - Create a new tool under `tools/` and register it with the MCP server.

--- a/agents/feature_engineering_agent.py
+++ b/agents/feature_engineering_agent.py
@@ -45,6 +45,7 @@ TEMPORAL_NAMESPACE = os.environ.get("TEMPORAL_NAMESPACE", "default")
 TASK_QUEUE = os.environ.get("TASK_QUEUE", "mcp-tools")
 FEATURE_WINDOW_SEC = int(os.environ.get("VECTOR_WINDOW_SEC", "300"))
 VECTOR_CONTINUE_EVERY = int(os.environ.get("VECTOR_CONTINUE_EVERY", "3600"))
+VECTOR_HISTORY_LIMIT = int(os.environ.get("VECTOR_HISTORY_LIMIT", "9000"))
 
 STOP_EVENT = asyncio.Event()
 TASKS: set[asyncio.Task[Any]] = set()
@@ -186,7 +187,7 @@ async def _signal_tick(client: Client, symbol: str, tick: dict) -> None:
         task_queue=TASK_QUEUE,
         start_signal="market_tick",
         start_signal_args=[tick],
-        args=[symbol, FEATURE_WINDOW_SEC, VECTOR_CONTINUE_EVERY],
+        args=[symbol, FEATURE_WINDOW_SEC, VECTOR_CONTINUE_EVERY, VECTOR_HISTORY_LIMIT],
     )
 
 


### PR DESCRIPTION
## Summary
- automatically continue when workflow history grows too large
- expose `VECTOR_HISTORY_LIMIT` and `STREAM_HISTORY_LIMIT`
- pass limits when starting feature workflows
- document new env vars

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'temporalio')*

------
https://chatgpt.com/codex/tasks/task_e_684b338bc3908330ab73cf461be979de