### PR TITLE
Fix history length retrieval

### DIFF
--- a/tools/feature_engineering.py
+++ b/tools/feature_engineering.py
@@ -153,7 +153,7 @@ class ComputeFeatureVector:
                 schedule_to_close_timeout=timedelta(seconds=5),
             )
             cycles += 1
-            hist_len = workflow.get_current_history_length()
+            hist_len = workflow.info().get_current_history_length()
             if hist_len >= history_limit or workflow.is_continue_as_new_suggested():
                 await workflow.continue_as_new(
                     symbol=symbol,

--- a/tools/market_data.py
+++ b/tools/market_data.py
@@ -84,7 +84,7 @@ class SubscribeCEXStream:
             cycles += 1
             if max_cycles is not None and cycles >= max_cycles:
                 return
-            hist_len = workflow.get_current_history_length()
+            hist_len = workflow.info().get_current_history_length()
             if hist_len >= history_limit or workflow.is_continue_as_new_suggested():
                 await workflow.continue_as_new(
                     exchange=exchange,


### PR DESCRIPTION
## Summary
- use `workflow.info()` to fetch history length

## Testing
- `pytest -q` *(fails: cannot import name 'docker_service' from 'temporalio.testing')*

------
https://chatgpt.com/codex/tasks/task_e_684b37ff20488330b98e92ae840da688