### PR TITLE
Fix continue as new check

### DIFF
--- a/tools/feature_engineering.py
+++ b/tools/feature_engineering.py
@@ -154,7 +154,7 @@ class ComputeFeatureVector:
             )
             cycles += 1
             hist_len = workflow.info().get_current_history_length()
-            if hist_len >= history_limit or workflow.is_continue_as_new_suggested():
+            if hist_len >= history_limit or workflow.info().is_continue_as_new_suggested():
                 await workflow.continue_as_new(
                     symbol=symbol,
                     window_sec=window_sec,

--- a/tools/market_data.py
+++ b/tools/market_data.py
@@ -85,7 +85,7 @@ class SubscribeCEXStream:
             if max_cycles is not None and cycles >= max_cycles:
                 return
             hist_len = workflow.info().get_current_history_length()
-            if hist_len >= history_limit or workflow.is_continue_as_new_suggested():
+            if hist_len >= history_limit or workflow.info().is_continue_as_new_suggested():
                 await workflow.continue_as_new(
                     exchange=exchange,
                     symbols=symbols,


### PR DESCRIPTION
## Summary
- address missing `is_continue_as_new_suggested` call

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'temporalio')*

------
https://chatgpt.com/codex/tasks/task_e_684b3a2527388330bd5398aaa65c4aa4