### PR TITLE
Fix continue_as_new usage

### DIFF
--- a/tools/feature_engineering.py
+++ b/tools/feature_engineering.py
@@ -156,15 +156,15 @@ class ComputeFeatureVector:
             hist_len = workflow.info().get_current_history_length()
             if hist_len >= history_limit or workflow.info().is_continue_as_new_suggested():
                 await workflow.continue_as_new(
-                    symbol=symbol,
-                    window_sec=window_sec,
-                    continue_every=continue_every,
-                    history_limit=history_limit,
+                    symbol,
+                    window_sec,
+                    continue_every,
+                    history_limit,
                 )
             if cycles >= continue_every:
                 await workflow.continue_as_new(
-                    symbol=symbol,
-                    window_sec=window_sec,
-                    continue_every=continue_every,
-                    history_limit=history_limit,
+                    symbol,
+                    window_sec,
+                    continue_every,
+                    history_limit,
                 )

--- a/tools/market_data.py
+++ b/tools/market_data.py
@@ -87,20 +87,20 @@ class SubscribeCEXStream:
             hist_len = workflow.info().get_current_history_length()
             if hist_len >= history_limit or workflow.info().is_continue_as_new_suggested():
                 await workflow.continue_as_new(
-                    exchange=exchange,
-                    symbols=symbols,
-                    interval_sec=interval_sec,
-                    max_cycles=max_cycles,
-                    continue_every=continue_every,
-                    history_limit=history_limit,
+                    exchange,
+                    symbols,
+                    interval_sec,
+                    max_cycles,
+                    continue_every,
+                    history_limit,
                 )
             if cycles >= continue_every:
                 await workflow.continue_as_new(
-                    exchange=exchange,
-                    symbols=symbols,
-                    interval_sec=interval_sec,
-                    max_cycles=max_cycles,
-                    continue_every=continue_every,
-                    history_limit=history_limit,
+                    exchange,
+                    symbols,
+                    interval_sec,
+                    max_cycles,
+                    continue_every,
+                    history_limit,
                 )
             await workflow.sleep(interval_sec)


### PR DESCRIPTION
## Summary
- fix `continue_as_new` calls by passing args positionally

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'temporalio')*

------
https://chatgpt.com/codex/tasks/task_e_684b3dfd81388330963b1044c8c2131c