### PR TITLE
Fix continue_as_new argument usage

### DIFF
--- a/tools/feature_engineering.py
+++ b/tools/feature_engineering.py
@@ -156,15 +156,19 @@ class ComputeFeatureVector:
             hist_len = workflow.info().get_current_history_length()
             if hist_len >= history_limit or workflow.info().is_continue_as_new_suggested():
                 await workflow.continue_as_new(
-                    symbol,
-                    window_sec,
-                    continue_every,
-                    history_limit,
+                    args=[
+                        symbol,
+                        window_sec,
+                        continue_every,
+                        history_limit,
+                    ]
                 )
             if cycles >= continue_every:
                 await workflow.continue_as_new(
-                    symbol,
-                    window_sec,
-                    continue_every,
-                    history_limit,
+                    args=[
+                        symbol,
+                        window_sec,
+                        continue_every,
+                        history_limit,
+                    ]
                 )

--- a/tools/market_data.py
+++ b/tools/market_data.py
@@ -87,20 +87,24 @@ class SubscribeCEXStream:
             hist_len = workflow.info().get_current_history_length()
             if hist_len >= history_limit or workflow.info().is_continue_as_new_suggested():
                 await workflow.continue_as_new(
-                    exchange,
-                    symbols,
-                    interval_sec,
-                    max_cycles,
-                    continue_every,
-                    history_limit,
+                    args=[
+                        exchange,
+                        symbols,
+                        interval_sec,
+                        max_cycles,
+                        continue_every,
+                        history_limit,
+                    ]
                 )
             if cycles >= continue_every:
                 await workflow.continue_as_new(
-                    exchange,
-                    symbols,
-                    interval_sec,
-                    max_cycles,
-                    continue_every,
-                    history_limit,
+                    args=[
+                        exchange,
+                        symbols,
+                        interval_sec,
+                        max_cycles,
+                        continue_every,
+                        history_limit,
+                    ]
                 )
             await workflow.sleep(interval_sec)


### PR DESCRIPTION
## Summary
- fix argument passing to `continue_as_new`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'temporalio')*

------
https://chatgpt.com/codex/tasks/task_e_684b41f016988330a2892d9cbc18a9bd