### PR TITLE
Log ledger recordings in mock exec agent

### DIFF
--- a/agents/execution/mock_exec_agent.py
+++ b/agents/execution/mock_exec_agent.py
@@ -74,6 +74,7 @@ async def _update_ledger(fill: dict) -> None:
     await _ensure_workflow(client)
     handle = client.get_workflow_handle(LEDGER_WF_ID)
     await handle.signal("record_fill", fill)
+    logger.info("Recorded execution to ledger: %s", fill)
 
 
 async def _place_order(_session: aiohttp.ClientSession | None, intent: dict) -> None:


### PR DESCRIPTION
## Summary
- log `info` message when recording a fill in `mock_exec_agent`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'temporalio')*

------
https://chatgpt.com/codex/tasks/task_e_684c3ca6322083309cc8280a471abc7c