### PR TITLE
Rename momentum agent to momentum_service

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ This starts the Temporal dev server, Python worker, MCP server and several sampl
    ```
 3. `SubscribeCEXStream` records ticks to the `market_tick` signal.
 4. The feature engineering agent processes those ticks via `ComputeFeatureVector`.
-5. The momentum agent emits buy/sell signals using `EvaluateStrategyMomentum` and continues processing while the tool runs.
+5. The momentum service emits buy/sell signals using `EvaluateStrategyMomentum` and continues processing while the tool runs.
 6. The ensemble agent approves intents with `PreTradeRiskCheck` and publishes them to the `IntentBus`.
 7. The mock execution agent picks up approved intents and prints simulated order fills.
 

--- a/agents/strategies/momentum_service.py
+++ b/agents/strategies/momentum_service.py
@@ -1,4 +1,4 @@
-"""Simple momentum trading strategy agent."""
+"""Simple momentum trading strategy service."""
 
 from __future__ import annotations
 
@@ -163,9 +163,9 @@ async def _run_tool(session: aiohttp.ClientSession, payload: dict) -> None:
 
 
 async def main() -> None:
-    """Run the momentum strategy agent."""
+    """Run the momentum strategy service."""
     print_banner(
-        "Momentum Strategy Agent",
+        "Momentum Strategy Service",
         "Emit buy/sell signals via SMA crossover",
     )
 
@@ -219,7 +219,7 @@ async def main() -> None:
                 await _ensure_workflow(client, symbol)
                 handles[symbol] = client.get_workflow_handle(_wf_id(symbol))
                 last_sig[symbol] = 0
-                logger.info("Momentum agent now watching %s", symbol)
+                logger.info("Momentum service now watching %s", symbol)
 
             handle = handles[symbol]
             await handle.signal("add_vector", vector)

--- a/run_stack.sh
+++ b/run_stack.sh
@@ -29,7 +29,7 @@ fi
 # │ worker/main.py│ feature_engineering_agent.py │
 # ├───────────────┼────────────────────────┤
 # │ Pane 5        │ Pane 4                 │
-# │ (shell)       │ momentum_agent.py      │
+# │ (shell)       │ momentum_service.py      │
 # ├───────────────┼────────────────────────┤
 # │ Pane 6        │ Pane 7                 │
 # │ shared_bus.py │ execution/mock_exec_agent.py │
@@ -62,7 +62,7 @@ tmux send-keys    -t $FE_PANE 'sleep 2 && source .venv/bin/activate && PYTHONPAT
 # 5. Pane 4 – momentum strategy agent (split Pane 3 vertically ↓)
 tmux select-pane  -t $FE_PANE
 MOM_PANE=$(tmux split-window -v -P -F "#{pane_id}")
-tmux send-keys    -t $MOM_PANE 'sleep 2 && source .venv/bin/activate && PYTHONPATH="$PWD" python agents/strategies/momentum_agent.py' C-m
+tmux send-keys    -t $MOM_PANE 'sleep 2 && source .venv/bin/activate && PYTHONPATH="$PWD" python agents/strategies/momentum_service.py' C-m
 
 tmux select-layout -t $SESSION:0 tiled
 

--- a/tests/test_ensure_workflows.py
+++ b/tests/test_ensure_workflows.py
@@ -12,7 +12,7 @@ from agents.ensemble.ensemble_agent import (
     _ensure_workflow as ensure_ensemble,
     ENSEMBLE_WF_ID,
 )
-from agents.strategies.momentum_agent import (
+from agents.strategies.momentum_service import (
     _ensure_workflow as ensure_momentum,
     MOMENTUM_WF_ID,
 )


### PR DESCRIPTION
## Summary
- rename `momentum_agent` to `momentum_service`
- update README walkthrough to mention momentum service
- adjust tmux script and tests to point at new file
- tweak banner comment in the service script

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'temporalio')*

------
https://chatgpt.com/codex/tasks/task_e_684c4098fc4c8330a4d52c2b5f6bc2a2