### PR TITLE
Enhance ledger with entry prices

### DIFF
--- a/agents/broker_agent.py
+++ b/agents/broker_agent.py
@@ -86,9 +86,11 @@ async def _get_status() -> Dict[str, object]:
     pnl = await handle.query("get_pnl")
     try:
         positions = await handle.query("get_positions")
+        entry_prices = await handle.query("get_entry_prices")
     except Exception:  # pragma: no cover - older workflow version
         positions = {}
-    return {"cash": cash, "pnl": pnl, "positions": positions}
+        entry_prices = {}
+    return {"cash": cash, "pnl": pnl, "positions": positions, "entry_prices": entry_prices}
 
 
 async def _format_status(status: Dict[str, object]) -> str:
@@ -96,10 +98,12 @@ async def _format_status(status: Dict[str, object]) -> str:
     cash = status.get("cash", 0.0)
     pnl = status.get("pnl", 0.0)
     positions = status.get("positions", {})
+    entry_prices = status.get("entry_prices", {})
 
     default = (
         f"Cash: ${cash:.2f}\n"
         f"Holdings: {positions}\n"
+        f"Entry Prices: {entry_prices}\n"
         f"Gains/Losses: ${pnl:.2f}"
     )
 

--- a/agents/ensemble/ensemble_agent.py
+++ b/agents/ensemble/ensemble_agent.py
@@ -103,9 +103,11 @@ async def _get_ledger_status(client: Client) -> Dict[str, Any]:
     cash = await handle.query("get_cash")
     try:
         positions = await handle.query("get_positions")
+        entry_prices = await handle.query("get_entry_prices")
     except Exception:  # pragma: no cover - older workflow version
         positions = {}
-    return {"cash": cash, "positions": positions}
+        entry_prices = {}
+    return {"cash": cash, "positions": positions, "entry_prices": entry_prices}
 
 
 async def _fetch(
@@ -191,12 +193,14 @@ async def _risk_check(_session: aiohttp.ClientSession | None, intent: Dict[str, 
     prompt = (
         "Current cash: ${cash:.2f}\n"
         "Positions: {positions}\n"
+        "Entry prices: {entry_prices}\n"
         "Intent: {intent}\n"
         "Risk result: {risk}\n"
         "Respond with APPROVE or REJECT followed by a colon and the reason."
     ).format(
         cash=status.get("cash", 0.0),
         positions=status.get("positions"),
+        entry_prices=status.get("entry_prices"),
         intent=intent,
         risk=result,
     )

--- a/tests/test_ledger_pnl.py
+++ b/tests/test_ledger_pnl.py
@@ -17,3 +17,39 @@ def test_pnl_uses_initial_cash_and_unrealized_value():
     wf.last_price["BTC/USD"] = Decimal("1100")
     assert wf.get_pnl() == pytest.approx(1000.0)
 
+
+def test_entry_price_tracking():
+    wf = ExecutionLedgerWorkflow()
+    wf.record_fill({
+        "side": "BUY",
+        "symbol": "ETH/USD",
+        "qty": 2,
+        "fill_price": 100,
+        "cost": 200,
+    })
+    assert wf.get_entry_prices()["ETH/USD"] == pytest.approx(100.0)
+    wf.record_fill({
+        "side": "BUY",
+        "symbol": "ETH/USD",
+        "qty": 2,
+        "fill_price": 120,
+        "cost": 240,
+    })
+    assert wf.get_entry_prices()["ETH/USD"] == pytest.approx(110.0)
+    wf.record_fill({
+        "side": "SELL",
+        "symbol": "ETH/USD",
+        "qty": 1,
+        "fill_price": 130,
+        "cost": 130,
+    })
+    assert wf.get_entry_prices()["ETH/USD"] == pytest.approx(110.0)
+    wf.record_fill({
+        "side": "SELL",
+        "symbol": "ETH/USD",
+        "qty": 3,
+        "fill_price": 115,
+        "cost": 345,
+    })
+    assert "ETH/USD" not in wf.get_entry_prices()
+

--- a/tests/test_risk_llm.py
+++ b/tests/test_risk_llm.py
@@ -41,7 +41,7 @@ async def fake_get_client():
     return DummyClient()
 
 async def fake_get_ledger_status(_client):
-    return {"cash": 1000.0, "positions": {}}
+    return {"cash": 1000.0, "positions": {}, "entry_prices": {}}
 
 @pytest.mark.asyncio
 async def test_risk_check_llm_approve(monkeypatch):


### PR DESCRIPTION
## Summary
- track weighted average entry prices in `ExecutionLedgerWorkflow`
- expose entry prices via broker/ensemble helpers
- include entry prices in ensemble LLM prompt
- display entry prices in broker status output
- test entry price calculations

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'temporalio')*

------
https://chatgpt.com/codex/tasks/task_e_684c50fdcf2883309877c930041b8f75