### PR TITLE
Improve logging readability

### DIFF
--- a/agents/ensemble/ensemble_agent.py
+++ b/agents/ensemble/ensemble_agent.py
@@ -21,7 +21,7 @@ from agents.shared_bus import enqueue_intent
 from agents.workflows import EnsembleWorkflow
 from tools.intent_bus import IntentBus
 from tools.risk import PreTradeRiskCheck
-from agents.utils import print_banner
+from agents.utils import print_banner, format_log
 from temporalio.client import Client
 from temporalio.service import RPCError, RPCStatusCode
 
@@ -265,9 +265,15 @@ async def _poll_signals(session: aiohttp.ClientSession) -> None:
                     enqueue_intent(intent)
                     await _broadcast_intent(client, intent)
                     await handle.signal("record_intent", intent)
-                    logger.info("Enqueued intent: %s", intent)
+                    logger.info(
+                        "Enqueued intent:\n%s",
+                        format_log(intent),
+                    )
                 else:
-                    logger.info("Intent rejected: %s", intent)
+                    logger.info(
+                        "Intent rejected:\n%s",
+                        format_log(intent),
+                    )
                 cursor = max(cursor, ts)
             except RPCError as err:  # pragma: no cover - network failures
                 logger.warning(

--- a/agents/execution/mock_exec_agent.py
+++ b/agents/execution/mock_exec_agent.py
@@ -12,7 +12,7 @@ from temporalio.client import Client
 from temporalio.service import RPCError, RPCStatusCode
 from agents.workflows import ExecutionLedgerWorkflow
 from tools.execution import PlaceMockOrder
-from agents.utils import print_banner
+from agents.utils import print_banner, format_log
 
 try:
     from agents.shared_bus import APPROVED_INTENT_QUEUE
@@ -74,7 +74,10 @@ async def _update_ledger(fill: dict) -> None:
     await _ensure_workflow(client)
     handle = client.get_workflow_handle(LEDGER_WF_ID)
     await handle.signal("record_fill", fill)
-    logger.info("Recorded execution to ledger: %s", fill)
+    logger.info(
+        "Recorded execution to ledger:\n%s",
+        format_log(fill),
+    )
 
 
 async def _place_order(_session: aiohttp.ClientSession | None, intent: dict) -> None:

--- a/agents/feature_engineering_agent.py
+++ b/agents/feature_engineering_agent.py
@@ -13,7 +13,7 @@ from temporalio.client import Client
 from temporalio.service import RPCError, RPCStatusCode
 
 from agents.workflows import FeatureStoreWorkflow
-from agents.utils import print_banner
+from agents.utils import print_banner, format_log
 
 
 def _add_project_root_to_path() -> None:
@@ -172,7 +172,12 @@ async def _store_vector(symbol: str, ts: int, vector: dict) -> None:
     handle = client.get_workflow_handle(FEATURE_WF_ID)
     await handle.signal("add_vector", args=[symbol, ts, vector])
     if ts % LOG_EVERY == 0:
-        logger.info("Stored vector for %s @ %d: %s", symbol, ts, vector)
+        logger.info(
+            "Stored vector for %s @ %d:\n%s",
+            symbol,
+            ts,
+            format_log(vector),
+        )
 
 
 async def _signal_tick(client: Client, symbol: str, tick: dict) -> None:

--- a/agents/strategies/momentum_service.py
+++ b/agents/strategies/momentum_service.py
@@ -24,7 +24,7 @@ def _add_project_root_to_path() -> None:
 _add_project_root_to_path()
 from agents.feature_engineering_agent import subscribe_vectors  # noqa: E402
 from agents.workflows import MomentumWorkflow  # noqa: E402
-from agents.utils import print_banner
+from agents.utils import print_banner, format_log
 from temporalio.client import Client  # noqa: E402
 from temporalio.service import RPCError, RPCStatusCode  # noqa: E402
 
@@ -157,7 +157,10 @@ async def _run_tool(session: aiohttp.ClientSession, payload: dict) -> None:
         return
     wf_id, run_id = wf
     result = await _poll_tool(session, wf_id, run_id)
-    logger.info("Tool completed with result: %s", result)
+    logger.info(
+        "Tool completed with result:\n%s",
+        format_log(result),
+    )
     if result:
         await _record_signal(session, result)
 

--- a/agents/utils.py
+++ b/agents/utils.py
@@ -11,5 +11,16 @@ def print_banner(name: str, purpose: str) -> None:
         print(f"* {line.ljust(width - 4)} *")
     print(border)
 
-__all__ = ["print_banner"]
+from pprint import pformat
+from typing import Any
+
+
+def format_log(data: Any) -> str:
+    """Return a pretty string representation of ``data`` for logging."""
+    if isinstance(data, str):
+        return data
+    return pformat(data, width=60)
+
+
+__all__ = ["print_banner", "format_log"]
 


### PR DESCRIPTION
## Summary
- add `format_log` helper to pretty-print objects
- use `format_log` in server and agents

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for temporalio, aiohttp)*

------
https://chatgpt.com/codex/tasks/task_e_684c58aae1308330a84738ab5198b41f