### PR TITLE
Rename feature engineering agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ and `VECTOR_HISTORY_LIMIT` environment variables.
 
 ## Development Workflow
 - Create a new tool under `tools/` and register it with the MCP server.
-- Write a strategy agent in `agents/` that calls your tool via the MCP client SDK. Use `subscribe_vectors(symbol)` from `agents.feature_engineering_agent` to stream processed feature rows into your strategy logic.
+- Write a strategy agent in `agents/` that calls your tool via the MCP client SDK. Use `subscribe_vectors(symbol)` from `agents.feature_engineering_service` to stream processed feature rows into your strategy logic.
 - Unit-test determinism with `make replay` to replay recent workflows.
 - Hot-reload – both MCP server and Python workers use `--watch` for instant feedback.
 - Deploy – push to `main`; CI builds a Docker image and promotes to your Temporal namespace.

--- a/agents/feature_engineering_service.py
+++ b/agents/feature_engineering_service.py
@@ -236,10 +236,10 @@ async def _shutdown() -> None:
 
 
 async def main() -> None:
-    """Run the feature engineering agent."""
+    """Run the Feature Engineering Service."""
 
     print_banner(
-        "Feature Engineering Agent",
+        "Feature Engineering Service",
         "Compute and store feature vectors",
     )
 

--- a/agents/strategies/momentum_service.py
+++ b/agents/strategies/momentum_service.py
@@ -22,7 +22,7 @@ def _add_project_root_to_path() -> None:
 
 
 _add_project_root_to_path()
-from agents.feature_engineering_agent import subscribe_vectors  # noqa: E402
+from agents.feature_engineering_service import subscribe_vectors  # noqa: E402
 from agents.workflows import MomentumWorkflow  # noqa: E402
 from agents.utils import print_banner, format_log
 from temporalio.client import Client  # noqa: E402

--- a/run_stack.sh
+++ b/run_stack.sh
@@ -26,7 +26,7 @@ fi
 # │ temporal dev  │ mcp_server/app.py      │
 # ├───────────────┼────────────────────────┤
 # │ Pane 1        │ Pane 3                 │
-# │ worker/main.py│ feature_engineering_agent.py │
+# │ worker/main.py│ feature_engineering_service.py │
 # ├───────────────┼────────────────────────┤
 # │ Pane 5        │ Pane 4                 │
 # │ (shell)       │ momentum_service.py      │
@@ -54,10 +54,10 @@ tmux select-pane  -t $SESSION:0.0
 MCP_PANE=$(tmux split-window -h -P -F "#{pane_id}")
 tmux send-keys    -t $MCP_PANE 'source .venv/bin/activate && PYTHONPATH="$PWD" python mcp_server/app.py' C-m
 
-# 4. Pane 3 – feature engineering agent (split Pane 1 horizontally →)
+# 4. Pane 3 – feature engineering service (split Pane 1 horizontally →)
 tmux select-pane  -t $WORKER_PANE
 FE_PANE=$(tmux split-window -h -P -F "#{pane_id}")
-tmux send-keys    -t $FE_PANE 'sleep 2 && source .venv/bin/activate && PYTHONPATH="$PWD" python agents/feature_engineering_agent.py' C-m
+tmux send-keys    -t $FE_PANE 'sleep 2 && source .venv/bin/activate && PYTHONPATH="$PWD" python agents/feature_engineering_service.py' C-m
 
 # 5. Pane 4 – momentum strategy agent (split Pane 3 vertically ↓)
 tmux select-pane  -t $FE_PANE

--- a/tests/test_ensure_workflows.py
+++ b/tests/test_ensure_workflows.py
@@ -4,7 +4,7 @@ import pytest
 from temporalio.testing import docker_service
 from temporalio.client import Client
 
-from agents.feature_engineering_agent import (
+from agents.feature_engineering_service import (
     _ensure_workflow as ensure_feature,
     FEATURE_WF_ID,
 )

--- a/tests/test_subscribe_vectors_stop.py
+++ b/tests/test_subscribe_vectors_stop.py
@@ -1,6 +1,6 @@
 import pytest
 
-from agents.feature_engineering_agent import (
+from agents.feature_engineering_service import (
     subscribe_vectors,
     STOP_EVENT,
     _store_vector,


### PR DESCRIPTION
## Summary
- rename feature engineering agent file to service
- update imports, README, run_stack script and tests
- adjust banner output

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'temporalio')*

------
https://chatgpt.com/codex/tasks/task_e_684c7bc8309c8330a1a3b2abcaa6c9d1