### PR TITLE
Refactor feature store workflow

### DIFF
--- a/tests/test_feature_store_workflow.py
+++ b/tests/test_feature_store_workflow.py
@@ -1,0 +1,23 @@
+import pytest
+
+from agents.workflows import FeatureStoreWorkflow
+
+
+def test_feature_store_queries():
+    wf = FeatureStoreWorkflow()
+    # Add vectors out of order for two symbols
+    wf.add_vector("BTC", 2, {"v": 2})
+    wf.add_vector("BTC", 1, {"v": 1})
+    wf.add_vector("ETH", 5, {"v": 5})
+
+    assert wf.latest_vector("BTC") == {"v": 2}
+    assert wf.latest_vector("ETH") == {"v": 5}
+    assert wf.latest_vector("XRP") is None
+
+    # Retrieve next vectors
+    assert wf.next_vector("BTC", 0) == (1, {"v": 1})
+    assert wf.next_vector("BTC", 1) == (2, {"v": 2})
+    assert wf.next_vector("BTC", 2) is None
+    assert wf.next_vector("ETH", 4) == (5, {"v": 5})
+    assert wf.next_vector("ETH", 5) is None
+


### PR DESCRIPTION
## Summary
- make feature store store vectors per symbol
- query `latest_vector` and `next_vector` via ordered lists
- test feature store queries

## Testing
- `pytest tests/test_feature_store_workflow.py -q`
- `pytest -q` *(fails: cannot import `docker_service` from `temporalio.testing`)*

------
https://chatgpt.com/codex/tasks/task_e_684c808159fc83308a008c4dffa0edad