### PR TITLE
Cache discovered workflows

### DIFF
--- a/mcp_server/app.py
+++ b/mcp_server/app.py
@@ -33,7 +33,7 @@ if str(root_dir) not in sys.path:
 
 # Global Temporal client and workflow registry
 client: Client | None = None
-workflows: dict[str, Callable[..., Any]]
+workflows: dict[str, Callable[..., Any]] = {}
 signal_log: dict[str, list[dict]] = {}
 _client_lock = asyncio.Lock()
 
@@ -77,7 +77,7 @@ def _discover_workflows() -> dict[str, Callable[..., Any]]:
 
 def _resolve_workflow(name: str) -> Callable[..., Any]:
     """Return workflow callable for ``name`` or raise 404."""
-    wf = _discover_workflows().get(name)
+    wf = workflows.get(name)
     if wf is None:
         logger.error("Unknown tool requested: %s", name)
         raise HTTPException(status_code=404, detail="Unknown tool")

--- a/tests/test_start_tool_discovery.py
+++ b/tests/test_start_tool_discovery.py
@@ -1,0 +1,42 @@
+import types
+
+from fastapi.testclient import TestClient
+import mcp_server.app as mapp
+
+
+class DummyHandle:
+    run_id = "run"
+    result_run_id = "run"
+
+
+class DummyClient:
+    async def start_workflow(self, *args, **kwargs):
+        return DummyHandle()
+
+
+def test_start_tool_uses_cached_workflows(monkeypatch):
+    calls = {"count": 0}
+
+    def fake_discover():
+        calls["count"] += 1
+
+        async def dummy_tool() -> None:
+            return None
+
+        return {"DummyTool": dummy_tool}
+
+    async def fake_get_client():
+        return DummyClient()
+
+    monkeypatch.setattr(mapp, "_discover_workflows", fake_discover)
+    monkeypatch.setattr(mapp, "get_temporal_client", fake_get_client)
+
+    # Simulate lifespan startup
+    mapp.workflows = fake_discover()
+    mapp.client = None
+
+    client = TestClient(mapp.app.streamable_http_app())
+    resp = client.post("/tools/DummyTool", json={})
+    assert resp.status_code == 202
+    assert calls["count"] == 1
+


### PR DESCRIPTION
## Summary
- reuse discovered workflow dictionary rather than rediscovering workflows
- add regression test for cached workflow lookups

## Testing
- `./.venv/bin/python -m pytest tests/test_start_tool_discovery.py -q`
- `./.venv/bin/python -m pytest -q` *(fails: ImportError: cannot import name 'docker_service')*

------
https://chatgpt.com/codex/tasks/task_e_684c806dea988330a8e82f10ec026b12