### PR TITLE
Rename mock execution agent to service

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Temporal supplies resilient workflows while MCP gives agents a shared, tool-base
                                                   │ intents
                                                   ▼
                                          ┌──────────────────┐
-                                         │ Execution Agent  │
+                                         │ Execution Service│
                                          └────────┬─────────┘
                                                   │ fills
                                                   ▼
@@ -111,7 +111,7 @@ This starts the Temporal dev server, Python worker, MCP server and several sampl
 4. The feature engineering service processes those ticks via `ComputeFeatureVector`.
 5. The momentum service emits buy/sell signals using `EvaluateStrategyMomentum` and continues processing while the tool runs.
 6. The ensemble agent approves intents with `PreTradeRiskCheck` and publishes them to the `IntentBus`.
-7. The mock execution agent picks up approved intents and prints simulated order fills.
+7. The mock execution service picks up approved intents and prints simulated order fills.
 
 If Binance is blocked in your region, pass `"exchange": "coinbaseexchange"` when starting workflows such as `SubscribeCEXStream`. Use trading pairs like `BTC/USD`. For private Coinbase endpoints, set `COINBASEEXCHANGE_API_KEY` and `COINBASEEXCHANGE_SECRET` in your environment.
 

--- a/agents/execution/mock_exec_service.py
+++ b/agents/execution/mock_exec_service.py
@@ -1,4 +1,4 @@
-"""Mock execution agent that simulates order fills."""
+"""Mock execution service that simulates order fills."""
 
 from __future__ import annotations
 
@@ -151,7 +151,7 @@ async def _run() -> None:
 
 async def main() -> None:
     print_banner(
-        "Mock Execution Agent",
+        "Mock Execution Service",
         "Simulate order execution",
     )
 

--- a/run_stack.sh
+++ b/run_stack.sh
@@ -32,7 +32,7 @@ fi
 # │ (shell)       │ momentum_service.py      │
 # ├───────────────┼────────────────────────┤
 # │ Pane 6        │ Pane 7                 │
-# │ shared_bus.py │ execution/mock_exec_agent.py │
+# │ shared_bus.py │ execution/mock_exec_service.py │
 # ├───────────────┴────────────────────────┤
 # │ Pane 8                                │
 # │ ensemble/ensemble_agent.py            │
@@ -76,10 +76,10 @@ tmux select-pane  -t $BROKER_PANE
 BLANK_PANE=$(tmux split-window -v -P -F "#{pane_id}")
 tmux send-keys    -t $BLANK_PANE 'sleep 2 && source .venv/bin/activate' C-m
 
-# 8. Pane 7 – mock execution agent (split Pane 6 horizontally →)
+# 8. Pane 7 – mock execution service (split Pane 6 horizontally →)
 tmux select-pane  -t $BLANK_PANE
 EXEC_PANE=$(tmux split-window -h -P -F "#{pane_id}")
-tmux send-keys    -t $EXEC_PANE 'sleep 2 && source .venv/bin/activate && PYTHONPATH="$PWD" python agents/execution/mock_exec_agent.py' C-m
+tmux send-keys    -t $EXEC_PANE 'sleep 2 && source .venv/bin/activate && PYTHONPATH="$PWD" python agents/execution/mock_exec_service.py' C-m
 
 # 9. Pane 8 – ensemble agent (split Pane 7 vertically ↓)
 tmux select-pane  -t $EXEC_PANE

--- a/tests/test_ensure_workflows.py
+++ b/tests/test_ensure_workflows.py
@@ -16,7 +16,7 @@ from agents.strategies.momentum_service import (
     _ensure_workflow as ensure_momentum,
     MOMENTUM_WF_ID,
 )
-from agents.execution.mock_exec_agent import (
+from agents.execution.mock_exec_service import (
     _ensure_workflow as ensure_ledger,
     LEDGER_WF_ID,
 )

--- a/tests/test_sell_validation.py
+++ b/tests/test_sell_validation.py
@@ -1,6 +1,6 @@
 import pytest
 
-from agents.execution import mock_exec_agent as mea
+from agents.execution import mock_exec_service as mea
 
 class DummyHandle:
     async def query(self, what):


### PR DESCRIPTION
## Summary
- rename `mock_exec_agent.py` to `mock_exec_service.py`
- update references to use new name
- adjust documentation and run_stack script for new service name

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'temporalio')*

------
https://chatgpt.com/codex/tasks/task_e_685ac62485448330a09ac7c705dd2fc5