### PR TITLE
Improve logging for demo network failures

### DIFF
--- a/tools/feature_engineering.py
+++ b/tools/feature_engineering.py
@@ -11,12 +11,17 @@ from temporalio import activity, workflow
 import aiohttp
 import os
 import asyncio
+import logging
 
 SMA_SHORT_MIN = int(os.environ.get("SMA_SHORT_MIN", "1"))
 SMA_LONG_MIN = int(os.environ.get("SMA_LONG_MIN", "5"))
 VECTOR_WINDOW_SEC = int(os.environ.get("VECTOR_WINDOW_SEC", str(SMA_LONG_MIN * 60)))
 VECTOR_CONTINUE_EVERY = int(os.environ.get("VECTOR_CONTINUE_EVERY", "3600"))
 VECTOR_HISTORY_LIMIT = int(os.environ.get("VECTOR_HISTORY_LIMIT", "9000"))
+
+LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO")
+logging.basicConfig(level=LOG_LEVEL, format="[%(asctime)s] %(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
 
 MCP_HOST = os.environ.get("MCP_HOST", "localhost")
 MCP_PORT = os.environ.get("MCP_PORT", "8080")
@@ -85,8 +90,8 @@ async def record_vector(vector: dict) -> None:
     async with aiohttp.ClientSession(timeout=timeout) as session:
         try:
             await session.post(url, json=vector)
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.error("Failed to record vector: %s", exc)
 
 
 @workflow.defn

--- a/tools/intent_bus.py
+++ b/tools/intent_bus.py
@@ -8,9 +8,14 @@ from datetime import timedelta
 
 import aiohttp
 from temporalio import activity, workflow
+import logging
 
 MCP_HOST = os.environ.get("MCP_HOST", "localhost")
 MCP_PORT = os.environ.get("MCP_PORT", "8080")
+
+LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO")
+logging.basicConfig(level=LOG_LEVEL, format="[%(asctime)s] %(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
 
 
 @activity.defn
@@ -21,8 +26,8 @@ async def emit_intent(intent: dict) -> None:
     async with aiohttp.ClientSession(timeout=timeout) as session:
         try:
             await session.post(url, json=intent)
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.error("Failed to emit intent: %s", exc)
 
 
 @workflow.defn

--- a/tools/market_data.py
+++ b/tools/market_data.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel
 from temporalio import activity, workflow
 import aiohttp
 import os
+import logging
 
 
 class MarketTick(BaseModel):
@@ -25,6 +26,10 @@ MCP_PORT = os.environ.get("MCP_PORT", "8080")
 STREAM_CONTINUE_EVERY = int(os.environ.get("STREAM_CONTINUE_EVERY", "3600"))
 STREAM_HISTORY_LIMIT = int(os.environ.get("STREAM_HISTORY_LIMIT", "9000"))
 
+LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO")
+logging.basicConfig(level=LOG_LEVEL, format="[%(asctime)s] %(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+
 
 @activity.defn
 async def fetch_ticker(exchange: str, symbol: str) -> dict[str, Any]:
@@ -35,6 +40,9 @@ async def fetch_ticker(exchange: str, symbol: str) -> dict[str, Any]:
     try:
         data = await client.fetch_ticker(symbol)
         return MarketTick(exchange=exchange, symbol=symbol, data=data).model_dump()
+    except Exception as exc:
+        logger.error("Failed to fetch ticker %s:%s - %s", exchange, symbol, exc)
+        raise
     finally:
         await client.close()
 
@@ -47,8 +55,8 @@ async def record_tick(tick: dict) -> None:
     async with aiohttp.ClientSession(timeout=timeout) as session:
         try:
             await session.post(url, json=tick)
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.error("Failed to record tick: %s", exc)
 
 
 @workflow.defn


### PR DESCRIPTION
## Summary
- add logger configurations to market data, feature engineering, and intent bus tools
- log errors when network requests fail

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_685b3cc99950833095c36414e0a06ce6