### PR TITLE
Enhance CEX stream logging

### DIFF
--- a/mcp_server/app.py
+++ b/mcp_server/app.py
@@ -66,14 +66,20 @@ async def subscribe_cex_stream(exchange: str, symbols: List[str], interval_sec: 
         symbols,
         interval_sec,
     )
-    handle = await client.start_workflow(
-        SubscribeCEXStream.run,
-        exchange,
-        symbols,
-        interval_sec,
-        id=workflow_id,
-        task_queue="mcp-tools",
-    )
+    logger.debug("Launching workflow %s", workflow_id)
+    try:
+        handle = await client.start_workflow(
+            SubscribeCEXStream.run,
+            exchange,
+            symbols,
+            interval_sec,
+            id=workflow_id,
+            task_queue="mcp-tools",
+        )
+    except Exception:
+        logger.exception("Failed to start SubscribeCEXStream workflow %s", workflow_id)
+        raise
+    logger.debug("Workflow handle created: %s", handle)
     logger.info("Workflow %s started run %s", workflow_id, handle.run_id)
     return {"workflow_id": workflow_id, "run_id": handle.run_id}
 


### PR DESCRIPTION
## Summary
- add extra debug output and error handling in `subscribe_cex_stream`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'temporalio')*

------
https://chatgpt.com/codex/tasks/task_e_685b780d914883308358c0bc0ed5e55a