### PR TITLE
Fix ensemble agent ChatGPT response parsing

### DIFF
--- a/agents/ensemble_agent_client.py
+++ b/agents/ensemble_agent_client.py
@@ -90,11 +90,45 @@ async def run_ensemble_agent(server_url: str = "http://localhost:8080") -> None:
                         tool_choice="auto",
                     )
                     msg = response.choices[0].message
-                    if msg.get("function_call"):
-                        func_name = msg["function_call"]["name"]
-                        func_args = json.loads(
-                            msg["function_call"].get("arguments") or "{}"
+
+                    # Newer versions of the OpenAI SDK return a ChatCompletionMessage
+                    # object. Inspect its attributes instead of treating it like a
+                    # dictionary.
+                    if getattr(msg, "tool_calls", None):
+                        conversation.append(
+                            {
+                                "role": msg.role,
+                                "content": msg.content,
+                                "tool_calls": [tc.model_dump() for tc in msg.tool_calls],
+                            }
                         )
+                        for tool_call in msg.tool_calls:
+                            func_name = tool_call.function.name
+                            func_args = json.loads(tool_call.function.arguments or "{}")
+                            print(
+                                f"[EnsembleAgent] Tool requested: {func_name} {func_args}"
+                            )
+                            result = await session.call_tool(func_name, func_args)
+                            conversation.append(
+                                {
+                                    "role": "tool",
+                                    "tool_call_id": tool_call.id,
+                                    "name": func_name,
+                                    "content": json.dumps(result),
+                                }
+                            )
+                        continue
+
+                    if getattr(msg, "function_call", None):
+                        conversation.append(
+                            {
+                                "role": msg.role,
+                                "content": msg.content,
+                                "function_call": msg.function_call.model_dump(),
+                            }
+                        )
+                        func_name = msg.function_call.name
+                        func_args = json.loads(msg.function_call.arguments or "{}")
                         print(
                             f"[EnsembleAgent] Tool requested: {func_name} {func_args}"
                         )
@@ -108,7 +142,7 @@ async def run_ensemble_agent(server_url: str = "http://localhost:8080") -> None:
                         )
                         continue
 
-                    assistant_reply = msg.get("content", "")
+                    assistant_reply = msg.content or ""
                     conversation.append(
                         {"role": "assistant", "content": assistant_reply}
                     )


### PR DESCRIPTION
## Summary
- handle new `ChatCompletionMessage` objects from the OpenAI SDK
- parse `tool_calls` and `function_call` attributes instead of using `.get`

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'docker_service' from 'temporalio.testing')*

------
https://chatgpt.com/codex/tasks/task_e_685ed1a625cc8330b8b27fccf773e83a