### PR TITLE
Fix bad trading pair handling

### DIFF
--- a/tests/test_fetch_ticker.py
+++ b/tests/test_fetch_ticker.py
@@ -1,0 +1,26 @@
+import asyncio
+import pytest
+
+from tools.market_data import fetch_ticker
+
+
+class DummyExchange:
+    def __init__(self):
+        self.symbols = ["BTC/USD"]
+
+    async def load_markets(self):
+        pass
+
+    async def fetch_ticker(self, symbol):
+        return {"symbol": symbol}
+
+    async def close(self):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_fetch_ticker_invalid_symbol(monkeypatch):
+    import ccxt.async_support as ccxt
+    monkeypatch.setattr(ccxt, "coinbaseexchange", DummyExchange)
+    with pytest.raises(ValueError):
+        await fetch_ticker("coinbaseexchange", "ETH/USD")

--- a/tools/market_data.py
+++ b/tools/market_data.py
@@ -38,6 +38,9 @@ async def fetch_ticker(exchange: str, symbol: str) -> dict[str, Any]:
     exchange_cls = getattr(ccxt, exchange.lower())
     client = exchange_cls()
     try:
+        await client.load_markets()
+        if symbol not in getattr(client, "symbols", []):
+            raise ValueError(f"Unsupported trading pair {symbol} on {exchange}")
         data = await client.fetch_ticker(symbol)
         return MarketTick(exchange=exchange, symbol=symbol, data=data).model_dump()
     except Exception as exc:


### PR DESCRIPTION
## Summary
- raise a friendly error for unsupported CEX pairs
- add unit test covering the invalid pair case

## Testing
- `pytest tests/test_fetch_ticker.py -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68606b8519ec833090c0a06f0e62f992