### PR TITLE
Handle empty tick window

### DIFF
--- a/tools/feature_engineering.py
+++ b/tools/feature_engineering.py
@@ -145,6 +145,10 @@ class ComputeFeatureVector:
                     pruned.append(t)
             self._ticks = pruned
 
+            if not self._ticks:
+                # Wait for a new tick if all have expired
+                continue
+
             vector = await workflow.execute_activity(
                 compute_indicators,
                 self._ticks,


### PR DESCRIPTION
## Summary
- avoid `ValueError` when the tick window becomes empty by skipping computation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mcp')*

------
https://chatgpt.com/codex/tasks/task_e_6860a49f32cc8330ae588bce6806c225