### PR TITLE
Fix MCP endpoint URLs

### DIFF
--- a/agents/broker_agent_client.py
+++ b/agents/broker_agent_client.py
@@ -159,7 +159,7 @@ async def get_next_broker_command() -> str | None:
     return await asyncio.to_thread(input, "> ")
 
 async def run_broker_agent(server_url: str = "http://localhost:8080"):
-    url = server_url.rstrip("/") + "/mcp"
+    url = server_url.rstrip("/") + "/mcp/"
     logger.info("Connecting to MCP server at %s", url)
     async with streamablehttp_client(url) as (read_stream, write_stream, _):
         async with ClientSession(read_stream, write_stream) as session:

--- a/agents/strategies/momentum_service.py
+++ b/agents/strategies/momentum_service.py
@@ -37,10 +37,13 @@ logger = logging.getLogger(__name__)
 
 MCP_HOST = os.environ.get("MCP_HOST", "localhost")
 MCP_PORT = os.environ.get("MCP_PORT", "8080")
-MCP_PATH = os.environ.get(
-    "MCP_BASE_PATH",
-    os.environ.get("FASTMCP_STREAMABLE_HTTP_PATH", "/mcp"),
-).rstrip("/")
+MCP_PATH = (
+    os.environ.get(
+        "MCP_BASE_PATH",
+        os.environ.get("FASTMCP_STREAMABLE_HTTP_PATH", "/mcp"),
+    ).rstrip("/")
+    + "/"
+)
 COOLDOWN_SEC = int(os.environ.get("COOLDOWN_SEC", "30"))
 LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO")
 POLL_INTERVAL = float(os.environ.get("POLL_INTERVAL", "0.5"))


### PR DESCRIPTION
## Summary
- ensure `MCP_PATH` always ends with `/`
- send broker agent to `/mcp/` directly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mcp')*

------
https://chatgpt.com/codex/tasks/task_e_6860a67c19c88330b61634e71be3c556