### PR TITLE
Improve agent logging

### DIFF
--- a/agents/ensemble_agent_client.py
+++ b/agents/ensemble_agent_client.py
@@ -4,6 +4,10 @@ import asyncio
 from typing import Any, AsyncIterator
 import aiohttp
 import openai
+
+ORANGE = "\033[33m"
+PINK = "\033[95m"
+RESET = "\033[0m"
 from mcp import ClientSession
 from mcp.client.streamable_http import streamablehttp_client
 from mcp.types import CallToolResult, TextContent
@@ -192,7 +196,7 @@ async def run_ensemble_agent(server_url: str = "http://localhost:8080") -> None:
                                 if func_name == "place_mock_order" and "intent" not in func_args:
                                     func_args["intent"] = intent
                                 print(
-                                    f"[EnsembleAgent] Tool requested: {func_name} {func_args}"
+                                    f"{ORANGE}[EnsembleAgent] Tool requested: {func_name} {func_args}{RESET}"
                                 )
                                 result = await session.call_tool(func_name, func_args)
                                 conversation.append(
@@ -221,7 +225,7 @@ async def run_ensemble_agent(server_url: str = "http://localhost:8080") -> None:
                             if func_name == "place_mock_order" and "intent" not in func_args:
                                 func_args["intent"] = intent
                             print(
-                                f"[EnsembleAgent] Tool requested: {func_name} {func_args}"
+                                f"{ORANGE}[EnsembleAgent] Tool requested: {func_name} {func_args}{RESET}"
                             )
                             result = await session.call_tool(func_name, func_args)
                             conversation.append(
@@ -237,7 +241,7 @@ async def run_ensemble_agent(server_url: str = "http://localhost:8080") -> None:
                         conversation.append(
                             {"role": "assistant", "content": assistant_reply}
                         )
-                        print(f"[EnsembleAgent] Decision: {assistant_reply}")
+                        print(f"{PINK}[EnsembleAgent] Decision: {assistant_reply}{RESET}")
                         conversation = [
                             {"role": "system", "content": SYSTEM_PROMPT}
                         ]


### PR DESCRIPTION
## Summary
- add color constants for logging output
- update Ensemble agent to colorize tool requests and decisions
- refactor Broker agent logging to use prints and colored output
- reduce Broker agent default log level to WARNING

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'temporalio')*

------
https://chatgpt.com/codex/tasks/task_e_6860d8b5727083308a7e229d91199e75