### PR TITLE
Fix deterministic timestamp in workflow

### DIFF
--- a/agents/workflows.py
+++ b/agents/workflows.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from collections import deque
-from datetime import datetime
 from decimal import Decimal
 from typing import Dict, List, Tuple
 
@@ -117,7 +116,7 @@ class MomentumWorkflow:
             if not side:
                 self.vectors.popleft()
                 continue
-            now = int(datetime.utcnow().timestamp())
+            now = int(workflow.now().timestamp())
             if now - self.last_sent < self.cooldown:
                 self.vectors.popleft()
                 continue


### PR DESCRIPTION
## Summary
- ensure deterministic workflow timestamps by using `workflow.now()` in `MomentumWorkflow`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'temporalio')*

------
https://chatgpt.com/codex/tasks/task_e_6860ddcd9ad08330a1d61171cea2c811