### PR TITLE
Use SSE for streaming signals

### DIFF
--- a/agents/utils.py
+++ b/agents/utils.py
@@ -14,7 +14,12 @@ def print_banner(name: str, purpose: str) -> None:
     print(border)
 
 from pprint import pformat
-from typing import Any
+from typing import Any, AsyncIterator, Optional
+
+import aiohttp
+import asyncio
+import json
+import logging
 
 
 def format_log(data: Any) -> str:
@@ -24,5 +29,59 @@ def format_log(data: Any) -> str:
     return pformat(data, width=60)
 
 
-__all__ = ["print_banner", "format_log"]
+
+async def sse_events(
+    session: aiohttp.ClientSession,
+    url: str,
+    *,
+    after: int = 0,
+    stop: Optional[asyncio.Event] = None,
+    log: Optional[logging.Logger] = None,
+) -> AsyncIterator[dict]:
+    """Yield events from ``url`` using server-sent events."""
+
+    stop_event = stop or asyncio.Event()
+    logger = log or logging.getLogger(__name__)
+    cursor = after
+    headers = {"Accept": "text/event-stream"}
+
+    while not stop_event.is_set():
+        params = {"after": cursor}
+        try:
+            async with session.get(url, params=params, headers=headers) as resp:
+                if resp.status != 200:
+                    logger.warning("SSE error %s", resp.status)
+                    await asyncio.sleep(1)
+                    continue
+
+                buffer = ""
+                data_buf = ""
+                async for chunk in resp.content.iter_any():
+                    if stop_event.is_set():
+                        break
+                    buffer += chunk.decode()
+                    while "\n" in buffer:
+                        line, buffer = buffer.split("\n", 1)
+                        line = line.rstrip()
+                        if line.startswith("data:"):
+                            data_buf += line[5:].strip()
+                        elif line == "":
+                            if data_buf:
+                                try:
+                                    event = json.loads(data_buf)
+                                except Exception:
+                                    event = None
+                                data_buf = ""
+                                if event is not None:
+                                    yield event
+                                    if "ts" in event:
+                                        cursor = max(cursor, int(event["ts"]))
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.error("SSE connection failed: %s", exc)
+            await asyncio.sleep(1)
+
+
+__all__ = ["print_banner", "format_log", "sse_events"]
 


### PR DESCRIPTION
## Summary
- stream signals using SSE in `mcp_server/app.py`
- add generic `sse_events` helper
- listen for streaming signals in feature_engineering, momentum, and ensemble services

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'temporalio', aiohttp)*

------
https://chatgpt.com/codex/tasks/task_e_6860ddad2c888330853d722b0c6b9703