### PR TITLE
Limit tick history by since_ts

### DIFF
--- a/agents/utils.py
+++ b/agents/utils.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from pprint import pformat
+from typing import Any
+
 
 def print_banner(name: str, purpose: str) -> None:
     """Print a simple ASCII banner with ``name`` and ``purpose``."""
@@ -12,9 +15,6 @@ def print_banner(name: str, purpose: str) -> None:
     for line in lines:
         print(f"* {line.ljust(width - 4)} *")
     print(border)
-
-from pprint import pformat
-from typing import Any
 
 
 def format_log(data: Any) -> str:

--- a/agents/workflows.py
+++ b/agents/workflows.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from collections import deque
 from decimal import Decimal
-from typing import Dict, List, Tuple
+from typing import Dict, List
 
 from temporalio import workflow
 

--- a/ticker_ui_service.py
+++ b/ticker_ui_service.py
@@ -12,7 +12,7 @@ import signal
 import threading
 import time
 from collections import deque
-from typing import Deque, Dict, List
+from typing import Deque, Dict, List, Tuple
 
 import requests
 


### PR DESCRIPTION
## Summary
- request historical ticks starting from the most recent sent timestamp
- include `since_ts` param in `get_historical_ticks` server tool
- update system prompt accordingly and remove tick truncation
- minor lint fixes for utils and ticker UI service

## Testing
- `ruff check . --fix`
- `pytest -q` *(fails: Failed starting test server: error sending request)*

------
https://chatgpt.com/codex/tasks/task_e_686aa2f4423883309f6af90cc696fec7