### PR TITLE
Enable interactive chat without pauses

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ This starts the Temporal dev server, Python worker, MCP server and several sampl
    analyzes market data to decide whether to trade using `place_mock_order`.
 5. Filled orders are recorded in the
    `ExecutionLedgerWorkflow`.
+6. You can type commands at the `>` prompt at any time to ask follow-up
+   questions or adjust the ensemble agent's behavior while it runs.
 
 
 `subscribe_cex_stream` automatically restarts itself via Temporal's *continue as new*

--- a/agents/ensemble_agent_client.py
+++ b/agents/ensemble_agent_client.py
@@ -80,6 +80,11 @@ def _tool_result_data(result: Any) -> Any:
     return result
 
 
+async def get_next_ensemble_command() -> str | None:
+    """Return the next user command from stdin."""
+    return await asyncio.to_thread(input, "> ")
+
+
 async def _watch_symbols(
     session: aiohttp.ClientSession,
     base_url: str,
@@ -181,8 +186,120 @@ async def _ensure_schedule(client: Client) -> None:
     await client.create_schedule(NUDGE_SCHEDULE_ID, schedule)
 
 
+async def _interactive_chat(
+    session: ClientSession,
+    tools: list,
+    conversation: list[dict],
+) -> None:
+    """Prompt the user for follow-ups until they enter an empty command."""
+    if openai_client is None:
+        return
+
+    tools_payload = [
+        {
+            "type": "function",
+            "function": {
+                "name": t.name,
+                "description": t.description,
+                "parameters": t.inputSchema,
+            },
+        }
+        for t in tools
+    ]
+
+    while True:
+        user_request = await get_next_ensemble_command()
+        if user_request is None:
+            await asyncio.sleep(1)
+            continue
+        if not user_request.strip():
+            break
+
+        logging.info("User command: %s", user_request)
+        conversation.append({"role": "user", "content": user_request})
+
+        while True:
+            try:
+                msg_dict = stream_chat_completion(
+                    openai_client,
+                    model=os.environ.get("OPENAI_MODEL", "gpt-4o"),
+                    messages=conversation,
+                    tools=tools_payload,
+                    tool_choice="auto",
+                    prefix="[EnsembleAgent] ",
+                    color=PINK,
+                    reset=RESET,
+                )
+            except Exception as exc:
+                logging.error("LLM request failed: %s", exc)
+                break
+
+            if "tool_calls" in msg_dict and msg_dict.get("tool_calls"):
+                conversation.append(msg_dict)
+                for call in msg_dict.get("tool_calls", []):
+                    func_name = call["function"]["name"]
+                    func_args = json.loads(call["function"].get("arguments") or "{}")
+                    if func_name not in ALLOWED_TOOLS:
+                        logging.warning("Tool not allowed: %s", func_name)
+                        continue
+                    print(
+                        f"{ORANGE}[EnsembleAgent] Tool requested: {func_name} {func_args}{RESET}"
+                    )
+                    try:
+                        result = await session.call_tool(func_name, func_args)
+                        result_data = _tool_result_data(result)
+                    except Exception as exc:
+                        logging.error("Tool call failed: %s", exc)
+                        continue
+                    conversation.append(
+                        {
+                            "role": "tool",
+                            "tool_call_id": call.get("id"),
+                            "content": json.dumps(result_data),
+                        }
+                    )
+                continue
+            elif msg_dict.get("function_call"):
+                conversation.append(msg_dict)
+                function_call = msg_dict["function_call"]
+                func_name = function_call.get("name")
+                if not func_name:
+                    logging.error("Received function_call without name: %s", msg_dict)
+                    continue
+                func_args = json.loads(function_call.get("arguments") or "{}")
+                if func_name not in ALLOWED_TOOLS:
+                    logging.warning("Tool not allowed: %s", func_name)
+                    continue
+                print(
+                    f"{ORANGE}[EnsembleAgent] Tool requested: {func_name} {func_args}{RESET}"
+                )
+                try:
+                    result = await session.call_tool(func_name, func_args)
+                    result_data = _tool_result_data(result)
+                except Exception as exc:
+                    logging.error("Tool call failed: %s", exc)
+                    continue
+                conversation.append(
+                    {
+                        "role": "function",
+                        "name": func_name,
+                        "content": json.dumps(result_data),
+                    }
+                )
+                continue
+            else:
+                assistant_msg = msg_dict.get("content", "")
+                conversation.append({"role": "assistant", "content": assistant_msg})
+                break
+
+        if len(conversation) > MAX_CONVERSATION_LENGTH:
+            conversation = [conversation[0]] + conversation[
+                -(MAX_CONVERSATION_LENGTH - 1) :
+            ]
+
+
 async def run_ensemble_agent(server_url: str = "http://localhost:8080") -> None:
-    """Run the ensemble agent and act on scheduled nudges."""
+    """Run the ensemble agent and act on scheduled nudges with optional chat."""
     base_url = server_url.rstrip("/")
     mcp_url = base_url + "/mcp/"
 
@@ -216,45 +333,52 @@ async def run_ensemble_agent(server_url: str = "http://localhost:8080") -> None:
                     [t.name for t in tools],
                 )
 
-                async for ts in _stream_nudges(http_session, base_url):
-                    if not symbols:
-                        continue
-                    print(f"[EnsembleAgent] Nudge @ {ts} for {sorted(symbols)}")
-                    if last_tick_ts:
-                        since_ts = min(last_tick_ts.values())
-                    else:
-                        since_ts = int(
-                            datetime.now(timezone.utc).timestamp()
-                        ) - TICK_LOOKBACK_DAYS * 86400
-                    res = await session.call_tool(
-                        "get_historical_ticks",
-                        {"symbols": sorted(symbols), "since_ts": since_ts},
-                    )
-                    history = _tool_result_data(res)
-                    new_history: Dict[str, list] = {}
-                    for sym, ticks in history.items():
-                        last_ts = last_tick_ts.get(sym, 0)
-                        valid_ticks = [t for t in ticks if t.get("ts", 0) > last_ts]
-                        if valid_ticks:
-                            new_history[sym] = valid_ticks
-                        if ticks:
-                            max_ts = max(t.get("ts", 0) for t in ticks)
-                            last_tick_ts[sym] = max(last_ts, max_ts)
-                    status_res = await session.call_tool("get_portfolio_status", {})
-                    status = _tool_result_data(status_res)
-                    info = {"portfolio": status, "history": new_history}
-                    conversation.append({"role": "user", "content": json.dumps(info)})
-                    openai_tools = [
-                        {
-                            "type": "function",
-                            "function": {
-                                "name": tool.name,
-                                "description": tool.description,
-                                "parameters": tool.inputSchema,
-                            },
-                        }
-                        for tool in tools
-                    ]
+                chat_task = asyncio.create_task(
+                    _interactive_chat(session, tools, conversation)
+                )
+                try:
+                    async for ts in _stream_nudges(http_session, base_url):
+                        if not symbols:
+                            continue
+                        print(f"[EnsembleAgent] Nudge @ {ts} for {sorted(symbols)}")
+                        if last_tick_ts:
+                            since_ts = min(last_tick_ts.values())
+                        else:
+                            since_ts = (
+                                int(datetime.now(timezone.utc).timestamp())
+                                - TICK_LOOKBACK_DAYS * 86400
+                            )
+                        res = await session.call_tool(
+                            "get_historical_ticks",
+                            {"symbols": sorted(symbols), "since_ts": since_ts},
+                        )
+                        history = _tool_result_data(res)
+                        new_history: Dict[str, list] = {}
+                        for sym, ticks in history.items():
+                            last_ts = last_tick_ts.get(sym, 0)
+                            valid_ticks = [t for t in ticks if t.get("ts", 0) > last_ts]
+                            if valid_ticks:
+                                new_history[sym] = valid_ticks
+                            if ticks:
+                                max_ts = max(t.get("ts", 0) for t in ticks)
+                                last_tick_ts[sym] = max(last_ts, max_ts)
+                        status_res = await session.call_tool("get_portfolio_status", {})
+                        status = _tool_result_data(status_res)
+                        info = {"portfolio": status, "history": new_history}
+                        conversation.append(
+                            {"role": "user", "content": json.dumps(info)}
+                        )
+                        openai_tools = [
+                            {
+                                "type": "function",
+                                "function": {
+                                    "name": tool.name,
+                                    "description": tool.description,
+                                    "parameters": tool.inputSchema,
+                                },
+                            }
+                            for tool in tools
+                        ]
                     while True:
                         msg = stream_chat_completion(
                             openai_client,
@@ -334,11 +458,186 @@ async def run_ensemble_agent(server_url: str = "http://localhost:8080") -> None:
                         break
 
                     if len(conversation) > MAX_CONVERSATION_LENGTH:
-                        conversation = [conversation[0]] + conversation[-(MAX_CONVERSATION_LENGTH - 1):]
+                        conversation = [conversation[0]] + conversation[
+                            -(MAX_CONVERSATION_LENGTH - 1) :
+                        ]
+                finally:
+                    chat_task.cancel()
+                    with contextlib.suppress(Exception):
+                        await chat_task
 
+
+async def run_ensemble_chat_agent(server_url: str = "http://localhost:8080") -> None:
+    """Interact with the ensemble agent via the terminal."""
+    url = server_url.rstrip("/") + "/mcp/"
+    logging.info("Connecting to MCP server at %s", url)
+    async with streamablehttp_client(url) as (read_stream, write_stream, _):
+        async with ClientSession(read_stream, write_stream) as session:
+            await session.initialize()
+            all_tools = (await session.list_tools()).tools
+            tools = [t for t in all_tools if t.name in ALLOWED_TOOLS]
+            conversation = [{"role": "system", "content": SYSTEM_PROMPT}]
+            print(
+                f"[EnsembleAgent] Connected to MCP server with tools: {[t.name for t in tools]}"
+            )
+
+            if openai_client is not None:
+                try:
+                    msg_dict = stream_chat_completion(
+                        openai_client,
+                        model=os.environ.get("OPENAI_MODEL", "gpt-4o"),
+                        messages=conversation,
+                        prefix="[EnsembleAgent] ",
+                        color=PINK,
+                        reset=RESET,
+                    )
+                    assistant_msg = msg_dict.get("content", "")
+                    conversation.append({"role": "assistant", "content": assistant_msg})
+                except Exception as exc:
+                    logging.error("LLM request failed: %s", exc)
+            else:
+                print("[EnsembleAgent] Enter a command to begin chatting")
+
+            while True:
+                user_request = await get_next_ensemble_command()
+                if user_request is None:
+                    await asyncio.sleep(1)
+                    continue
+
+                if openai_client is None:
+                    logging.warning("LLM unavailable; echoing command.")
+                    continue
+
+                logging.info("User command: %s", user_request)
+                conversation.append({"role": "user", "content": user_request})
+
+                tools_payload = [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": t.name,
+                            "description": t.description,
+                            "parameters": t.inputSchema,
+                        },
+                    }
+                    for t in tools
+                ]
+
+                try:
+                    msg_dict = stream_chat_completion(
+                        openai_client,
+                        model=os.environ.get("OPENAI_MODEL", "gpt-4o"),
+                        messages=conversation,
+                        tools=tools_payload,
+                        tool_choice="auto",
+                        prefix="[EnsembleAgent] ",
+                        color=PINK,
+                        reset=RESET,
+                    )
+                except Exception as exc:
+                    logging.error("LLM request failed: %s", exc)
+                    continue
+
+                if "tool_calls" in msg_dict and msg_dict.get("tool_calls"):
+                    conversation.append(msg_dict)
+                    for call in msg_dict.get("tool_calls", []):
+                        func_name = call["function"]["name"]
+                        func_args = json.loads(
+                            call["function"].get("arguments") or "{}"
+                        )
+                        if func_name not in ALLOWED_TOOLS:
+                            logging.warning("Tool not allowed: %s", func_name)
+                            continue
+                        print(
+                            f"{ORANGE}[EnsembleAgent] Tool requested: {func_name} {func_args}{RESET}"
+                        )
+                        try:
+                            result = await session.call_tool(func_name, func_args)
+                            result_data = _tool_result_data(result)
+                        except Exception as exc:
+                            logging.error("Tool call failed: %s", exc)
+                            continue
+                        conversation.append(
+                            {
+                                "role": "tool",
+                                "tool_call_id": call.get("id"),
+                                "content": json.dumps(result_data),
+                            }
+                        )
+
+                    try:
+                        followup = stream_chat_completion(
+                            openai_client,
+                            model=os.environ.get("OPENAI_MODEL", "gpt-4o"),
+                            messages=conversation,
+                            tools=tools_payload,
+                            prefix="[EnsembleAgent] ",
+                            color=PINK,
+                            reset=RESET,
+                        )
+                        assistant_msg = followup.get("content", "")
+                        conversation.append(
+                            {"role": "assistant", "content": assistant_msg}
+                        )
+                    except Exception as exc:
+                        logging.error("LLM request failed: %s", exc)
+                        continue
+                elif msg_dict.get("function_call"):
+                    conversation.append(msg_dict)
+                    function_call = msg_dict["function_call"]
+                    func_name = function_call.get("name")
+                    if not func_name:
+                        logging.error(
+                            "Received function_call without name: %s", msg_dict
+                        )
+                        continue
+                    func_args = json.loads(function_call.get("arguments") or "{}")
+                    if func_name not in ALLOWED_TOOLS:
+                        logging.warning("Tool not allowed: %s", func_name)
+                        continue
+                    print(
+                        f"{ORANGE}[EnsembleAgent] Tool requested: {func_name} {func_args}{RESET}"
+                    )
+                    try:
+                        result = await session.call_tool(func_name, func_args)
+                        result_data = _tool_result_data(result)
+                    except Exception as exc:
+                        logging.error("Tool call failed: %s", exc)
+                        continue
+                    conversation.append(
+                        {
+                            "role": "function",
+                            "name": func_name,
+                            "content": json.dumps(result_data),
+                        }
+                    )
+                    try:
+                        followup = stream_chat_completion(
+                            openai_client,
+                            model=os.environ.get("OPENAI_MODEL", "gpt-4o"),
+                            messages=conversation,
+                            tools=tools_payload,
+                            prefix="[EnsembleAgent] ",
+                            color=PINK,
+                            reset=RESET,
+                        )
+                        assistant_msg = followup.get("content", "")
+                        conversation.append(
+                            {"role": "assistant", "content": assistant_msg}
+                        )
+                    except Exception as exc:
+                        logging.error("LLM request failed: %s", exc)
+                        continue
+                else:
+                    assistant_msg = msg_dict.get("content", "")
+                    conversation.append({"role": "assistant", "content": assistant_msg})
+
+                if len(conversation) > MAX_CONVERSATION_LENGTH:
+                    conversation = [conversation[0]] + conversation[
+                        -(MAX_CONVERSATION_LENGTH - 1) :
+                    ]
 
 
 if __name__ == "__main__":
-    asyncio.run(
-        run_ensemble_agent(os.environ.get("MCP_SERVER", "http://localhost:8080"))
-    )
+    server = os.environ.get("MCP_SERVER", "http://localhost:8080")
+    asyncio.run(run_ensemble_agent(server))


### PR DESCRIPTION
## Summary
- let ensemble agent accept commands anytime by running `_interactive_chat` concurrently
- remove per-cycle prompt pause and document new behavior

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'temporalio')*

------
https://chatgpt.com/codex/tasks/task_e_686adba1420c8330aa927c9bbbe2bbc1