### PR TITLE
Remove auto data fetch in ensemble agent

### DIFF
--- a/agents/ensemble_agent_client.py
+++ b/agents/ensemble_agent_client.py
@@ -47,15 +47,16 @@ openai_client = openai.OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 
 SYSTEM_PROMPT = (
     "You are a portfolio management agent that wakes every minute when nudged. "
-    "Each nudge message tells you the active symbols. Call `get_historical_ticks` "
-    "exactly once with **all** of those symbols and include a `since_ts` parameter so "
-    "you only fetch new data. Immediately after that, call `get_portfolio_status` "
-    "exactly once to review cash balances and open positions. Once you have this "
-    "information you may decide whether to place a trade using `place_mock_order` "
-    "which requires `symbol`, `side` (BUY or SELL), `qty`, `price` and `type` (market "
-    "or limit). Briefly explain your reasoning whenever you execute a trade. Always "
-    "evaluate the latest data for each active symbol before making a decision so "
-    "every pair is considered on each nudge."
+    "Each nudge message lists the active symbols. At the start of every nudge, "
+    "call `get_historical_ticks` once with **all** of those symbols and include a "
+    "`since_ts` parameter so you only fetch new data. Immediately afterward, call "
+    "`get_portfolio_status` once to review cash balances and open positions. Do not "
+    "repeat these two calls again until the next nudge. After reviewing this "
+    "information you may decide whether to place a trade using `place_mock_order`, "
+    "which must be invoked with a single `intent` object containing `symbol`, "
+    "`side` (BUY or SELL), `qty`, `price`, and `type` (market or limit). Briefly "
+    "explain your reasoning whenever you trade and always consider every active "
+    "symbol before making a decision."
 )
 
 


### PR DESCRIPTION
## Summary
- refactor ensemble agent client
- remove automatic calls to `get_historical_ticks` and `get_portfolio_status`
- update system prompt to instruct the agent to call those tools once per nudge
- simplify nudge handling and drop unused helpers

## Testing
- `pytest -q` *(fails: RuntimeError: Failed starting test server)*

------
https://chatgpt.com/codex/tasks/task_e_686c1d0af38c833082abfd58d197be3a