### PR TITLE
Remove hard-coded tick/status calls

### DIFF
--- a/agents/ensemble_agent_client.py
+++ b/agents/ensemble_agent_client.py
@@ -1,7 +1,7 @@
 import os
 import json
 import asyncio
-from typing import Any, AsyncIterator, Set, Dict
+from typing import Any, AsyncIterator, Set
 import aiohttp
 import openai
 import logging
@@ -9,7 +9,7 @@ from mcp import ClientSession
 from mcp.client.streamable_http import streamablehttp_client
 from agents.utils import stream_chat_completion
 from mcp.types import CallToolResult, TextContent
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 from temporalio.client import (
     Client,
     Schedule,
@@ -36,8 +36,6 @@ ALLOWED_TOOLS = {
 # broker agent applies the same limit to avoid exceeding the LLM context
 # window.
 MAX_CONVERSATION_LENGTH = 20
-# Maximum historical lookback in days for the initial tick request
-TICK_LOOKBACK_DAYS = int(os.environ.get("TICK_LOOKBACK_DAYS", "1"))
 
 NUDGE_SCHEDULE_ID = "ensemble-nudge"
 
@@ -196,8 +194,6 @@ async def run_ensemble_agent(server_url: str = "http://localhost:8080") -> None:
         _symbol_task = asyncio.create_task(
             _watch_symbols(http_session, base_url, symbols)
         )
-        # track the most recent tick timestamp sent for each symbol
-        last_tick_ts: Dict[str, int] = {}
         await _ensure_schedule(temporal)
 
         async with streamablehttp_client(mcp_url) as (
@@ -220,30 +216,14 @@ async def run_ensemble_agent(server_url: str = "http://localhost:8080") -> None:
                     if not symbols:
                         continue
                     print(f"[EnsembleAgent] Nudge @ {ts} for {sorted(symbols)}")
-                    if last_tick_ts:
-                        since_ts = min(last_tick_ts.values())
-                    else:
-                        since_ts = int(
-                            datetime.now(timezone.utc).timestamp()
-                        ) - TICK_LOOKBACK_DAYS * 86400
-                    res = await session.call_tool(
-                        "get_historical_ticks",
-                        {"symbols": sorted(symbols), "since_ts": since_ts},
+                    conversation.append(
+                        {
+                            "role": "user",
+                            "content": json.dumps(
+                                {"nudge": ts, "symbols": sorted(symbols)}
+                            ),
+                        }
                     )
-                    history = _tool_result_data(res)
-                    new_history: Dict[str, list] = {}
-                    for sym, ticks in history.items():
-                        last_ts = last_tick_ts.get(sym, 0)
-                        valid_ticks = [t for t in ticks if t.get("ts", 0) > last_ts]
-                        if valid_ticks:
-                            new_history[sym] = valid_ticks
-                        if ticks:
-                            max_ts = max(t.get("ts", 0) for t in ticks)
-                            last_tick_ts[sym] = max(last_ts, max_ts)
-                    status_res = await session.call_tool("get_portfolio_status", {})
-                    status = _tool_result_data(status_res)
-                    info = {"portfolio": status, "history": new_history}
-                    conversation.append({"role": "user", "content": json.dumps(info)})
                     openai_tools = [
                         {
                             "type": "function",
@@ -294,7 +274,7 @@ async def run_ensemble_agent(server_url: str = "http://localhost:8080") -> None:
                                         "role": "tool",
                                         "tool_call_id": tool_call["id"],
                                         "name": func_name,
-                                        "content": json.dumps(result.model_dump()),
+                                        "content": json.dumps(_tool_result_data(result)),
                                     }
                                 )
                             continue
@@ -322,7 +302,7 @@ async def run_ensemble_agent(server_url: str = "http://localhost:8080") -> None:
                                 {
                                     "role": "function",
                                     "name": func_name,
-                                    "content": json.dumps(result.model_dump()),
+                                    "content": json.dumps(_tool_result_data(result)),
                                 }
                             )
                             continue


### PR DESCRIPTION
## Summary
- simplify ensemble agent logic
- let the LLM call `get_historical_ticks` and `get_portfolio_status`
- stream tool results back using `_tool_result_data`

## Testing
- `pip install temporalio aiohttp asyncio mcp pydantic pytest fastapi uvicorn openai pandas numpy ccxt`
- `pip install pytest-asyncio`
- `pytest -q` *(fails: error sending request when starting temporal test server)*

------
https://chatgpt.com/codex/tasks/task_e_686c38cccbe08330a19658a5644235ac