### PR TITLE
Rename ensemble agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Temporal supplies resilient workflows while MCP gives agents a shared, tool-base
                   │ history
                   ▼
            ┌──────────────────┐
-           │ Ensemble Agent   │<─────────────┐
+           │ Execution Agent   │<─────────────┐
            └──────┬───────────┘              │
                   │ orders                   │ nudges
                   ▼                          │
@@ -88,7 +88,7 @@ Each block corresponds to one or more MCP tools (Temporal workflows) described b
 
 Required environment variables:
 
-- `OPENAI_API_KEY` – enables the broker and ensemble agents to use OpenAI models.
+- `OPENAI_API_KEY` – enables the broker and execution agents to use OpenAI models.
 - `COINBASEEXCHANGE_API_KEY` and `COINBASEEXCHANGE_SECRET` – API credentials for Coinbase Exchange.
 - `TEMPORAL_ADDRESS`, `TEMPORAL_NAMESPACE` and `TASK_QUEUE` – Temporal connection settings (defaults are shown in `.env`).
 - `MCP_PORT` – port for the MCP server (defaults to `8080`).
@@ -124,7 +124,7 @@ This starts the Temporal dev server, Python worker, MCP server and several sampl
    This instructs it to begin streaming data for every supported pair.
 3. `start_market_stream` spawns a `subscribe_cex_stream` workflow that
    broadcasts each ticker to its `ComputeFeatureVector` child.
-4. The ensemble agent wakes up periodically via a scheduled workflow and
+4. The execution agent wakes up periodically via a scheduled workflow and
    analyzes market data to decide whether to trade using `place_mock_order`.
 5. Filled orders are recorded in the
    `ExecutionLedgerWorkflow`.
@@ -141,7 +141,7 @@ and `VECTOR_HISTORY_LIMIT` environment variables.
 
 ## Repository Layout
 ```
-├── agents/          # Broker and ensemble agents
+├── agents/          # Broker and execution agents
 ├── tools/           # Durable workflows used as MCP tools
 ├── mcp_server/      # FastAPI server exposing the tools
 ├── worker/          # Temporal worker loading workflows

--- a/agents/execution_agent_client.py
+++ b/agents/execution_agent_client.py
@@ -161,7 +161,7 @@ async def _watch_symbols(
                         symbols.clear()
                         symbols.update(new_set)
                         print(
-                            f"[EnsembleAgent] Active symbols updated: {sorted(symbols)}"
+                            f"[ExecutionAgent] Active symbols updated: {sorted(symbols)}"
                         )
         except Exception:
             await asyncio.sleep(1)
@@ -224,8 +224,8 @@ async def _ensure_schedule(client: Client) -> None:
     await client.create_schedule(NUDGE_SCHEDULE_ID, schedule)
 
 
-async def run_ensemble_agent(server_url: str = "http://localhost:8080") -> None:
-    """Run the ensemble agent and act on scheduled nudges."""
+async def run_execution_agent(server_url: str = "http://localhost:8080") -> None:
+    """Run the execution agent and act on scheduled nudges."""
     base_url = server_url.rstrip("/")
     mcp_url = base_url + "/mcp/"
 
@@ -253,14 +253,14 @@ async def run_ensemble_agent(server_url: str = "http://localhost:8080") -> None:
                 tools = [t for t in all_tools if t.name in ALLOWED_TOOLS]
                 conversation = [{"role": "system", "content": SYSTEM_PROMPT}]
                 print(
-                    "[EnsembleAgent] Connected to MCP server with tools:",
+                    "[ExecutionAgent] Connected to MCP server with tools:",
                     [t.name for t in tools],
                 )
 
                 async for ts in _stream_nudges(http_session, base_url):
                     if not symbols:
                         continue
-                    print(f"[EnsembleAgent] Nudge @ {ts} for {sorted(symbols)}")
+                    print(f"[ExecutionAgent] Nudge @ {ts} for {sorted(symbols)}")
                     conversation.append(
                         {
                             "role": "user",
@@ -287,7 +287,7 @@ async def run_ensemble_agent(server_url: str = "http://localhost:8080") -> None:
                             messages=conversation,
                             tools=openai_tools,
                             tool_choice="auto",
-                            prefix="[EnsembleAgent] Decision: ",
+                            prefix="[ExecutionAgent] Decision: ",
                             color=PINK,
                             reset=RESET,
                         )
@@ -307,11 +307,11 @@ async def run_ensemble_agent(server_url: str = "http://localhost:8080") -> None:
                                 )
                                 if func_name not in ALLOWED_TOOLS:
                                     print(
-                                        f"[EnsembleAgent] Tool not allowed: {func_name}"
+                                        f"[ExecutionAgent] Tool not allowed: {func_name}"
                                     )
                                     continue
                                 print(
-                                    f"{ORANGE}[EnsembleAgent] Tool requested: {func_name} {func_args}{RESET}"
+                                    f"{ORANGE}[ExecutionAgent] Tool requested: {func_name} {func_args}{RESET}"
                                 )
                                 result = await session.call_tool(func_name, func_args)
                                 conversation.append(
@@ -337,10 +337,10 @@ async def run_ensemble_agent(server_url: str = "http://localhost:8080") -> None:
                                 msg["function_call"].get("arguments") or "{}"
                             )
                             if func_name not in ALLOWED_TOOLS:
-                                print(f"[EnsembleAgent] Tool not allowed: {func_name}")
+                                print(f"[ExecutionAgent] Tool not allowed: {func_name}")
                                 continue
                             print(
-                                f"{ORANGE}[EnsembleAgent] Tool requested: {func_name} {func_args}{RESET}"
+                                f"{ORANGE}[ExecutionAgent] Tool requested: {func_name} {func_args}{RESET}"
                             )
                             result = await session.call_tool(func_name, func_args)
                             conversation.append(
@@ -365,5 +365,5 @@ async def run_ensemble_agent(server_url: str = "http://localhost:8080") -> None:
 
 if __name__ == "__main__":
     asyncio.run(
-        run_ensemble_agent(os.environ.get("MCP_SERVER", "http://localhost:8080"))
+        run_execution_agent(os.environ.get("MCP_SERVER", "http://localhost:8080"))
     )

--- a/mcp_server/app.py
+++ b/mcp_server/app.py
@@ -84,7 +84,7 @@ async def start_market_stream(
 ) -> Dict[str, str]:
     """Convenience wrapper around ``subscribe_cex_stream``.
 
-    Also records the selected symbols for the ensemble agent.
+    Also records the selected symbols for the execution agent.
     """
     result = await subscribe_cex_stream(symbols, interval_sec)
     signal_log.setdefault("active_symbols", []).append(

--- a/run_stack.sh
+++ b/run_stack.sh
@@ -29,7 +29,7 @@ fi
 # │ worker/main.py│ broker_agent_client.py │
 # ├───────────────┼────────────────────────┤
 # │ Pane 4        │ Pane 5                 │
-# │ ensemble_agent_client.py │ ticker_ui_service.py    │
+# │ execution_agent_client.py │ ticker_ui_service.py    │
 # └────────────────────────────────────────┘
 ###############################################################################
 
@@ -52,10 +52,10 @@ tmux send-keys    -t $MCP_PANE 'source .venv/bin/activate && PYTHONPATH="$PWD" p
 tmux select-pane  -t $WORKER_PANE
 BROKER_PANE=$(tmux split-window -h -P -F "#{pane_id}")
 tmux send-keys    -t $BROKER_PANE 'sleep 2 && source .venv/bin/activate && PYTHONPATH="$PWD" python agents/broker_agent_client.py' C-m
-# 5. Pane 4 – ensemble agent (split Pane 3 vertically ↓)
+# 5. Pane 4 – execution agent (split Pane 3 vertically ↓)
 tmux select-pane  -t $BROKER_PANE
 ENS_PANE=$(tmux split-window -v -P -F "#{pane_id}")
-tmux send-keys    -t $ENS_PANE 'sleep 2 && source .venv/bin/activate && PYTHONPATH="$PWD" python agents/ensemble_agent_client.py' C-m
+tmux send-keys    -t $ENS_PANE 'sleep 2 && source .venv/bin/activate && PYTHONPATH="$PWD" python agents/execution_agent_client.py' C-m
 # 6. Pane 5 – ticker UI (split Pane 4 horizontally →)
 tmux select-pane  -t $ENS_PANE
 UI_PANE=$(tmux split-window -h -P -F "#{pane_id}")


### PR DESCRIPTION
## Summary
- rename EnsembleAgent to ExecutionAgent
- update function and logs to use execution agent wording
- tweak README, mcp_server app, and scripts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'temporalio')*

------
https://chatgpt.com/codex/tasks/task_e_686c4cd462d483309368caf290e6c6b2