### PR TITLE
Improve tool docs and add OrderIntent model

### DIFF
--- a/tools/execution.py
+++ b/tools/execution.py
@@ -4,21 +4,34 @@ from __future__ import annotations
 
 import logging
 from datetime import timedelta
-from typing import Dict
+from typing import Dict, Literal
+
+from pydantic import BaseModel
 
 from temporalio import activity, workflow
 from temporalio.common import RetryPolicy
 
 logger = logging.getLogger(__name__)
 
+class OrderIntent(BaseModel):
+    """Schema for order intents sent to :func:`place_mock_order`."""
+
+    symbol: str
+    side: Literal["BUY", "SELL"]
+    qty: float
+    price: float
+    type: Literal["market", "limit"]
+
+
 @activity.defn
-async def mock_fill(intent: Dict) -> Dict:
+async def mock_fill(intent: OrderIntent) -> Dict:
     """Return a fill dict for the provided intent."""
-    qty = float(intent.get("qty") or intent.get("volume", 0))
-    price = float(intent.get("price", 0))
+
+    qty = float(intent.qty)
+    price = float(intent.price)
     cost = qty * price
-    logger.info("Mock fill for %s %s @%s", intent["side"], qty, price)
-    return {**intent, "fill_price": price, "cost": cost}
+    logger.info("Mock fill for %s %s @%s", intent.side, qty, price)
+    return {**intent.model_dump(), "fill_price": price, "cost": cost}
 
 
 @workflow.defn
@@ -26,7 +39,7 @@ class PlaceMockOrder:
     """Workflow wrapper around :func:`mock_fill`."""
 
     @workflow.run
-    async def run(self, intent: Dict) -> Dict:
+    async def run(self, intent: OrderIntent) -> Dict:
         logger.info("Placing mock order: %s", intent)
         result: Dict = await workflow.execute_activity(
             mock_fill,


### PR DESCRIPTION
## Summary
- define `OrderIntent` data model for the execution tools
- document `place_mock_order` parameters and return values
- expand docs for `subscribe_cex_stream`, `start_market_stream`, `evaluate_strategy_momentum`, and `get_portfolio_status`

## Testing
- `pytest -q` *(fails: error sending request while starting Temporal test server)*

------
https://chatgpt.com/codex/tasks/task_e_686c8fe95310833091ce7f5915d793e3