### PR TITLE
Fix start_market_stream run_id

### DIFF
--- a/mcp_server/app.py
+++ b/mcp_server/app.py
@@ -87,8 +87,9 @@ async def subscribe_cex_stream(
         logger.exception("Failed to start SubscribeCEXStream workflow %s", workflow_id)
         raise
     logger.debug("Workflow handle created: %s", handle)
-    logger.info("Workflow %s started run %s", workflow_id, handle.run_id)
-    return {"workflow_id": workflow_id, "run_id": handle.run_id}
+    run_id = handle.first_execution_run_id or handle.result_run_id
+    logger.info("Workflow %s started run %s", workflow_id, run_id)
+    return {"workflow_id": workflow_id, "run_id": run_id}
 
 
 @app.tool(annotations={"title": "Start Market Stream", "readOnlyHint": True})


### PR DESCRIPTION
## Summary
- fix run_id retrieval for started workflows

## Testing
- `pytest -q` *(fails: error sending request)*

------
https://chatgpt.com/codex/tasks/task_e_686d416f19508330b250c6043afd6d5d