### PR TITLE
Handle developer tool result messages

### DIFF
--- a/agents/execution_agent_client.py
+++ b/agents/execution_agent_client.py
@@ -6,7 +6,7 @@ import openai
 import logging
 from mcp import ClientSession
 from mcp.client.streamable_http import streamablehttp_client
-from agents.utils import stream_chat_completion
+from agents.utils import stream_response
 from mcp.types import CallToolResult, TextContent
 from agents.context_manager import create_context_manager
 from datetime import timedelta
@@ -405,7 +405,7 @@ async def run_execution_agent(server_url: str = "http://localhost:8080") -> None
                     ]
                 while True:
                     try:
-                        msg = stream_chat_completion(
+                        msg = stream_response(
                             openai_client,
                             model=os.environ.get("OPENAI_MODEL", "gpt-5-mini"),
                             messages=conversation,
@@ -455,10 +455,14 @@ async def run_execution_agent(server_url: str = "http://localhost:8080") -> None
                             
                             conversation.append(
                                 {
-                                    "role": "tool",
-                                    "tool_call_id": tool_call["id"],
-                                    "name": func_name,
-                                    "content": json.dumps(result_data),
+                                    "role": "developer",
+                                    "content": [
+                                        {
+                                            "type": "tool_result",
+                                            "tool_call_id": tool_call["id"],
+                                            "output": result_data,
+                                        }
+                                    ],
                                 }
                             )
                         continue

--- a/tests/test_context_management.py
+++ b/tests/test_context_management.py
@@ -31,6 +31,7 @@ class TestContextManager:
                 "content": None,
                 "tool_calls": [
                     {
+                        "id": "call_1",
                         "function": {
                             "name": "get_portfolio_status",
                             "arguments": "{}"
@@ -39,9 +40,14 @@ class TestContextManager:
                 ]
             },
             {
-                "role": "tool",
-                "name": "get_portfolio_status", 
-                "content": '{"cash": 100000, "positions": {}}'
+                "role": "developer",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_call_id": "call_1",
+                        "output": {"cash": 100000, "positions": {}}
+                    }
+                ]
             }
         ]
         
@@ -60,7 +66,16 @@ class TestContextManager:
                 "role": "assistant",
                 "tool_calls": [{"function": {"name": "test_tool"}}]
             },
-            {"role": "tool", "name": "test_tool", "content": "result"}
+            {
+                "role": "developer",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_call_id": "test_call",
+                        "output": "result"
+                    }
+                ]
+            }
         ]
         
         formatted = manager._format_messages_for_summary(messages)
@@ -72,7 +87,7 @@ class TestContextManager:
         assert "Assistant: Assistant response" in formatted
         # Should format tool calls
         assert "Assistant called tool: test_tool" in formatted
-        assert "Tool test_tool returned data" in formatted
+        assert "Tool returned data" in formatted
     
     @pytest.mark.asyncio
     async def test_context_management_no_summarization_needed(self):


### PR DESCRIPTION
## Summary
- Stream tool results as `developer` messages with `tool_result` content in broker and execution agents
- Convert legacy tool messages in streaming helper and rename helper to `stream_response`
- Track `developer` tool results in context manager token counting and summarization
- Update context management tests for `developer` tool result format and add tokenizer fallback

## Testing
- `pytest tests/test_context_management.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68a3c59600d88330865879a3187e3b22